### PR TITLE
fix: enforce a single deck.gl runtime version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "dependencies": {
     "@carbonplan/zarr-layer": "^0.3.1",
-    "@deck.gl/aggregation-layers": "^9.2.6",
-    "@deck.gl/core": "^9.2.6",
-    "@deck.gl/geo-layers": "^9.2.6",
-    "@deck.gl/layers": "^9.2.6",
-    "@deck.gl/mapbox": "^9.2.6",
-    "@deck.gl/mesh-layers": "^9.2.6",
+    "@deck.gl/aggregation-layers": "9.2.7",
+    "@deck.gl/core": "9.2.7",
+    "@deck.gl/geo-layers": "9.2.7",
+    "@deck.gl/layers": "9.2.7",
+    "@deck.gl/mapbox": "9.2.7",
+    "@deck.gl/mesh-layers": "9.2.7",
     "@developmentseed/deck.gl-geotiff": "^0.2.0",
     "@geoman-io/maplibre-geoman-free": "^0.6.2",
     "@loaders.gl/core": "^4.3.4",
@@ -68,6 +68,15 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "@deck.gl/aggregation-layers": "9.2.7",
+    "@deck.gl/core": "9.2.7",
+    "@deck.gl/extensions": "9.2.7",
+    "@deck.gl/geo-layers": "9.2.7",
+    "@deck.gl/layers": "9.2.7",
+    "@deck.gl/mapbox": "9.2.7",
+    "@deck.gl/mesh-layers": "9.2.7"
   },
   "peerDependencies": {
     "maplibre-gl": ">=5.14.0"


### PR DESCRIPTION
## Summary
Ensure `anymap-ts` resolves to one deck.gl version to avoid runtime collisions in Jupyter (e.g. `multiple versions detected: 9.2.7 vs 9.2.6`).

## Changes
- Pin direct deck.gl dependencies to `9.2.7` (no caret ranges).
- Add npm `overrides` to force all deck.gl packages in the tree to `9.2.7`:
  - `@deck.gl/core`
  - `@deck.gl/layers`
  - `@deck.gl/geo-layers`
  - `@deck.gl/mapbox`
  - `@deck.gl/mesh-layers`
  - `@deck.gl/aggregation-layers`
  - `@deck.gl/extensions`

## Why
Deck.gl throws at runtime when more than one version is loaded on the same page. This patch makes dependency resolution deterministic.

## Validation
`npm ls` now resolves deck.gl packages to `9.2.7` in this repo dependency graph.
