### PR TITLE
fix: enforce single deck.gl 9.2.6 runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "dependencies": {
     "@carbonplan/zarr-layer": "^0.3.1",
-    "@deck.gl/aggregation-layers": "9.2.7",
-    "@deck.gl/core": "9.2.7",
-    "@deck.gl/geo-layers": "9.2.7",
-    "@deck.gl/layers": "9.2.7",
-    "@deck.gl/mapbox": "9.2.7",
-    "@deck.gl/mesh-layers": "9.2.7",
+    "@deck.gl/aggregation-layers": "9.2.6",
+    "@deck.gl/core": "9.2.6",
+    "@deck.gl/geo-layers": "9.2.6",
+    "@deck.gl/layers": "9.2.6",
+    "@deck.gl/mapbox": "9.2.6",
+    "@deck.gl/mesh-layers": "9.2.6",
     "@developmentseed/deck.gl-geotiff": "^0.2.0",
     "@geoman-io/maplibre-geoman-free": "^0.6.2",
     "@loaders.gl/core": "^4.3.4",
@@ -70,13 +70,13 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "@deck.gl/aggregation-layers": "9.2.7",
-    "@deck.gl/core": "9.2.7",
-    "@deck.gl/extensions": "9.2.7",
-    "@deck.gl/geo-layers": "9.2.7",
-    "@deck.gl/layers": "9.2.7",
-    "@deck.gl/mapbox": "9.2.7",
-    "@deck.gl/mesh-layers": "9.2.7"
+    "@deck.gl/aggregation-layers": "9.2.6",
+    "@deck.gl/core": "9.2.6",
+    "@deck.gl/extensions": "9.2.6",
+    "@deck.gl/geo-layers": "9.2.6",
+    "@deck.gl/layers": "9.2.6",
+    "@deck.gl/mapbox": "9.2.6",
+    "@deck.gl/mesh-layers": "9.2.6"
   },
   "peerDependencies": {
     "maplibre-gl": ">=5.14.0"


### PR DESCRIPTION
Root cause: map output currently ends up with mixed deck.gl runtimes (9.2.6 and 9.2.7) in the browser, which triggers the multiple-version error.

This patch aligns all deck.gl deps/overrides to 9.2.6 so a single runtime is bundled/loaded.

Validation done locally:
- rebuilt maplibre/deckgl bundles
- anymap_ts/static/maplibre.js and anymap_ts/static/deckgl.js contain 9.2.6 and no 9.2.7.
