### PR TITLE
Fix responsive resizing flicker/state loss for MapLibre widget

### DIFF
--- a/anymap_ts/maplibre.py
+++ b/anymap_ts/maplibre.py
@@ -48,7 +48,7 @@ class MapLibreMap(MapWidget):
         center: Tuple[float, float] = (0.0, 0.0),
         zoom: float = 2.0,
         width: str = "100%",
-        height: str = "700px",
+        height: str = "100%",
         style: Union[
             str, Dict
         ] = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
@@ -64,7 +64,7 @@ class MapLibreMap(MapWidget):
             center: Map center as (longitude, latitude).
             zoom: Initial zoom level.
             width: Map width as CSS string.
-            height: Map height as CSS string. Default is "700px".
+            height: Map height as CSS string. Default is "100%".
             style: MapLibre style URL or style object. Default is "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json".
             bearing: Map bearing in degrees.
             pitch: Map pitch in degrees.

--- a/src/maplibre/MapLibreRenderer.ts
+++ b/src/maplibre/MapLibreRenderer.ts
@@ -126,6 +126,21 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
   }
 
   /**
+   * Refresh container dimensions and trigger map resize.
+   * Used when host frameworks re-invoke render during layout changes.
+   */
+  refreshLayout(): void {
+    if (this.mapContainer) {
+      this.mapContainer.style.width = this.model.get('width') || '100%';
+      this.mapContainer.style.height = this.model.get('height') || '100%';
+    }
+
+    if (this.map) {
+      this.map.resize();
+    }
+  }
+
+  /**
    * Initialize the MapLibre map.
    */
   async initialize(): Promise<void> {


### PR DESCRIPTION
## Summary

This PR addresses #46 by improving how the MapLibre anywidget renderer behaves in responsive hosts like Panel.

### What changed
- Reuse the existing MapLibreRenderer when render() is re-invoked with the same model instead of tearing down/recreating the map.
- Add a short delayed cleanup guard so quick re-renders during layout changes do not destroy the map instance.
- Add refreshLayout() in MapLibreRenderer to apply current model width/height and call map.resize().
- Change MapLibreMap default Python height from "700px" to "100%" to better fill responsive parent containers.

### Impact
- Avoids visual flicker from unnecessary teardown/recreate cycles.
- Preserves map view state during responsive layout updates.
- Better default behavior for full-height responsive containers.

Closes #46
