### PR TITLE
Fix multi-cell rendering for MapLibre maps

### DIFF
--- a/src/core/BaseMapRenderer.ts
+++ b/src/core/BaseMapRenderer.ts
@@ -181,7 +181,8 @@ export abstract class BaseMapRenderer<TMap> {
   }
 
   /**
-   * Restore persisted state (layers, sources) from model.
+   * Restore persisted state (layers, sources, controls) from model.
+   * Called when the map is displayed in a subsequent cell.
    */
   protected restoreState(): void {
     // Restore sources first
@@ -194,6 +195,13 @@ export abstract class BaseMapRenderer<TMap> {
     const layers = this.model.get('_layers') || {};
     for (const [layerId, layerConfig] of Object.entries(layers)) {
       this.executeMethod('addLayer', [], layerConfig as unknown as Record<string, unknown>);
+    }
+
+    // Restore controls
+    const controls = this.model.get('_controls') || {};
+    for (const [controlId, controlConfig] of Object.entries(controls)) {
+      const config = controlConfig as { type: string; position: string; options?: Record<string, unknown> };
+      this.executeMethod('addControl', [config.type], { position: config.position, ...config.options });
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix issue where MapLibre maps would only show the basemap (without additional layers) when displayed in subsequent notebook cells
- Layers added via Python methods are now properly tracked in `_layers`, `_sources`, and `_layer_dict` traits

## Changes

### TypeScript (MapLibreRenderer.ts, BaseMapRenderer.ts)
- Call `restoreState()` in `initialize()` to restore layers, sources, and controls when map is displayed in subsequent cells
- Add state persistence to handler methods (`handleAddGeoJSON`, `handleAddTileLayer`, `handleAddBasemap`, `handleAddPMTilesLayer`) so layers are properly saved to model traits
- Enhance `restoreState()` in `BaseMapRenderer` to also restore controls

### Python (maplibre.py)
- Add `_add_to_layer_dict()` and `_remove_from_layer_dict()` helper methods to track layers by category for the layer control UI
- Update all layer methods to populate `_layer_dict` with appropriate categories:
  - `add_vector` → "Vector"
  - `add_tile_layer`, `add_cog`, `add_zarr` → "Raster"
  - `add_pmtiles` → "Vector" or "Raster" (based on source_type)
  - `add_arc_layer`, `add_point_cloud_layer` → "Deck.gl"
  - `add_lidar_layer` → "LiDAR"
  - `add_basemap` → "Basemaps"

## Test plan

- [x] Create a MapLibre map and add layers in one cell
- [x] Display the same map object in a subsequent cell
- [x] Verify all layers are properly restored
- [x] Check that `m._layers`, `m._sources`, and `m._layer_dict` are populated correctly