### PR TITLE
Fix: Bundle duckdb-wasm and shpjs for production build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     rollupOptions: {
-      external: ['@duckdb/duckdb-wasm', 'shpjs'],
       input: {
         main: resolve(__dirname, 'examples/index.html'),
         // MapLibre examples


### PR DESCRIPTION
## Summary
- Remove `@duckdb/duckdb-wasm` and `shpjs` from rollup external dependencies
- This ensures these packages are bundled in the production build for GitHub Pages

## Problem
The Control Grid example was failing on GitHub Pages with:
> Failed to convert GeoParquet: DuckDB WASM is not installed or failed to load

## Test plan
- [ ] Deploy to GitHub Pages and verify Control Grid example works
- [ ] Verify choropleth map can load GeoParquet data