### PR TITLE
Bump version: v0.6.1 -> v0.6.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build:all
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/anymap_ts/_version.py
+++ b/anymap_ts/_version.py
@@ -1,3 +1,3 @@
 """Version information for anymap-ts."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anymap-ts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "TypeScript frontend for anymap-ts interactive maps",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Update version to 0.6.2 in both Python (`_version.py`) and TypeScript (`package.json`)
- Add GitHub Actions workflow for automated npm publishing on release
- Fix npm publish workflow to use Node.js 22 LTS (instead of non-existent Node 24)
- Add npm caching and provenance support for supply chain security

## Changes
- `package.json`: version 0.6.1 → 0.6.2
- `anymap_ts/_version.py`: version 0.6.1 → 0.6.2
- `.github/workflows/publish.yml`: New workflow for npm publishing

## Test plan
- [ ] Verify version numbers are correct in both files
- [ ] After merge, create a GitHub release to trigger npm publish
- [ ] Ensure `NPM_TOKEN` secret is configured in repository settings