### PR TITLE
Fix npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,9 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Summary
- Fix npm workflow error: `npm ci` requires a lock file but `package-lock.json` is gitignored
- Remove `cache: 'npm'` option since it also requires lock file
- Use `npm install` instead of `npm ci`

## Issue
The workflow was failing with:
> Error: Dependencies lock file is not found. Supported file patterns: package-lock.json, npm-shrinkwrap.json, yarn.lock

## Test plan
- [ ] Merge and trigger a release to verify npm publish works