### PR TITLE
Fix repository URL format for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,13 @@
     "geospatial"
   ],
   "author": "Qiusheng Wu <giswqs@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opengeos/anymap-ts.git"
+  },
+  "homepage": "https://github.com/opengeos/anymap-ts",
+  "bugs": {
+    "url": "https://github.com/opengeos/anymap-ts/issues"
+  }
 }


### PR DESCRIPTION
## Summary
Fix the repository URL format in package.json to satisfy npm provenance requirements.

## Issue
npm publish with `--provenance` was failing with:
> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/opengeos/anymap-ts"

## Fix
Changed repository URL from:
```json
"url": "https://github.com/opengeos/anymap-ts"
```
To:
```json
"url": "git+https://github.com/opengeos/anymap-ts.git"
```

## Test plan
- [ ] Merge and re-run the release workflow