### PR TITLE
Fix layer control not working in Panel library

### DIFF
--- a/src/maplibre/index.ts
+++ b/src/maplibre/index.ts
@@ -16,6 +16,8 @@ import 'maplibre-gl-geo-editor/style.css';
 import 'maplibre-gl-layer-control/style.css';
 // Import LiDAR Control CSS
 import 'maplibre-gl-lidar/style.css';
+// Import custom styles (including Panel compatibility fixes)
+import '../styles/maplibre.css';
 
 // Register PMTiles protocol globally (must be called once before any map is created)
 const pmtilesProtocol = new Protocol();

--- a/src/maplibre/plugins/LayerControlPlugin.ts
+++ b/src/maplibre/plugins/LayerControlPlugin.ts
@@ -21,6 +21,7 @@ export interface LayerControlOptions {
 export class LayerControlPlugin {
   private map: MapLibreMap;
   private control: LayerControl | null = null;
+  private buttonClickHandler: ((e: MouseEvent) => void) | null = null;
 
   constructor(map: MapLibreMap) {
     this.map = map;
@@ -44,6 +45,49 @@ export class LayerControlPlugin {
     });
 
     this.map.addControl(this.control, position);
+
+    // Fix for Panel/IPyWidget compatibility:
+    // The layer control uses document.addEventListener("click") which doesn't
+    // work properly when the widget is embedded in Panel (due to shadow DOM
+    // or event propagation issues). We add a click handler on the button that
+    // stops propagation to prevent the document listener from interfering.
+    this.fixPanelCompatibility();
+  }
+
+  /**
+   * Fix compatibility with Panel library.
+   *
+   * Panel wraps ipywidgets in a way that can interfere with document-level
+   * event listeners. This method adds event handlers to ensure the layer
+   * control button works properly.
+   */
+  private fixPanelCompatibility(): void {
+    // Find the layer control container
+    const container = this.map.getContainer();
+    const controlContainer = container.querySelector('.maplibregl-ctrl-layer-control');
+
+    if (!controlContainer) {
+      // Retry after a short delay if not found immediately
+      setTimeout(() => this.fixPanelCompatibility(), 100);
+      return;
+    }
+
+    const button = controlContainer.querySelector('button');
+    if (!button) return;
+
+    // Add a capture-phase click handler that stops propagation
+    // This prevents the document-level click handler from closing the panel
+    // immediately after it opens
+    this.buttonClickHandler = (e: MouseEvent) => {
+      e.stopPropagation();
+    };
+
+    button.addEventListener('click', this.buttonClickHandler, true);
+
+    // Also add mousedown handler to ensure events reach the button
+    button.addEventListener('mousedown', (e: MouseEvent) => {
+      e.stopPropagation();
+    }, true);
   }
 
   /**
@@ -57,6 +101,17 @@ export class LayerControlPlugin {
    * Destroy the layer control.
    */
   destroy(): void {
+    // Clean up button click handler
+    if (this.buttonClickHandler) {
+      const container = this.map.getContainer();
+      const controlContainer = container.querySelector('.maplibregl-ctrl-layer-control');
+      const button = controlContainer?.querySelector('button');
+      if (button) {
+        button.removeEventListener('click', this.buttonClickHandler, true);
+      }
+      this.buttonClickHandler = null;
+    }
+
     if (this.control) {
       this.map.removeControl(this.control);
       this.control = null;

--- a/src/styles/maplibre.css
+++ b/src/styles/maplibre.css
@@ -131,3 +131,60 @@
 .anymap-draw-control button.active {
   background-color: #e0e0e0;
 }
+
+/* ===========================================================================
+ * Layer Control styles - Panel/IPyWidget compatibility fixes
+ * ===========================================================================
+ * These styles ensure the layer control works properly when the map is
+ * embedded in Panel library using pn.pane.IPyWidget.
+ */
+
+/* Ensure layer control button is clickable */
+.maplibregl-ctrl-layer-control {
+  position: relative;
+  z-index: 10;
+  pointer-events: auto !important;
+}
+
+.maplibregl-ctrl-layer-control button {
+  pointer-events: auto !important;
+  cursor: pointer !important;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Ensure layer control panel is clickable and visible */
+.layer-control-panel {
+  pointer-events: auto !important;
+  z-index: 1000 !important;
+}
+
+/* Ensure all interactive elements in the panel are clickable */
+.layer-control-panel input,
+.layer-control-panel button,
+.layer-control-panel .layer-control-item {
+  pointer-events: auto !important;
+}
+
+/* Fix for controls in Panel's IPyWidget wrapper */
+.jp-OutputArea-output .maplibregl-ctrl,
+.jupyter-widgets .maplibregl-ctrl,
+.widget-output .maplibregl-ctrl {
+  pointer-events: auto !important;
+}
+
+/* Ensure map controls are above any Panel overlays */
+.maplibregl-ctrl-top-left,
+.maplibregl-ctrl-top-right,
+.maplibregl-ctrl-bottom-left,
+.maplibregl-ctrl-bottom-right {
+  z-index: 10;
+  pointer-events: none;
+}
+
+.maplibregl-ctrl-top-left > *,
+.maplibregl-ctrl-top-right > *,
+.maplibregl-ctrl-bottom-left > *,
+.maplibregl-ctrl-bottom-right > * {
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary

Fixes #71 - The Layer Control button does not work when the map widget is embedded in Panel library.

### Problem
When using anymap-ts with Panel via `pn.pane.IPyWidget()`, the layer control button was unresponsive to clicks. This was caused by event propagation issues between Panel's widget wrapper and the document-level click listener in `maplibre-gl-layer-control`.

### Root Cause
The `maplibre-gl-layer-control` library uses `document.addEventListener("click", ...)` to detect clicks outside the control panel and close it. However, when the widget is embedded in Panel (which may use shadow DOM or different event propagation), this document-level listener interferes with the button click events.

### Solution
1. **Event propagation fix**: Added a capture-phase click handler on the layer control button that stops propagation, preventing the document listener from interfering with button clicks
2. **CSS fixes**: Added styles to ensure proper `z-index` and `pointer-events` for map controls when embedded in Panel's IPyWidget wrapper
3. **Import custom styles**: Ensured the custom CSS is bundled with the maplibre module

### Changes
- `src/maplibre/plugins/LayerControlPlugin.ts`: Added `fixPanelCompatibility()` method with event propagation fixes
- `src/styles/maplibre.css`: Added CSS rules for Panel/IPyWidget compatibility
- `src/maplibre/index.ts`: Import custom styles in the bundle

## Test plan
- [ ] Test layer control in Panel with `pn.pane.IPyWidget(m)`
- [ ] Verify layer control still works in Jupyter Notebook/Lab
- [ ] Verify layer control panel opens and closes correctly
- [ ] Verify opacity sliders and checkboxes work

### Related Resources
- [HoloViz Forum: Panel works with AnyWidget](https://discourse.holoviz.org/t/panel-works-with-anywidget/6466)
- [anywidget Issue #100](https://github.com/manzt/anywidget/issues/100) - Known compatibility issues