### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/anymap_ts/_version.py
+++ b/anymap_ts/_version.py
@@ -1,3 +1,3 @@
 """Version information for anymap-ts."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anymap-ts",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "TypeScript frontend for anymap-ts interactive maps",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump Python version to 0.7.1
- Bump TypeScript/npm version to 0.7.1

## Changes in 0.7.1
- Fix HTML export for `add_markers` and `add_legend` (#79, #77)
- Add legend support to MapLibre TypeScript renderer for Jupyter notebooks
- Add markers and legend example to `to_html` notebook
- Remove redundant `_get_default_template` method from maplibre.py