### PR TITLE
Add sky/fog, feature query/filter, video layer, and split map

### DIFF
--- a/anymap_ts/base.py
+++ b/anymap_ts/base.py
@@ -46,6 +46,9 @@ class MapWidget(anywidget.AnyWidget):
     # Drawing data
     _draw_data = traitlets.Dict({}).tag(sync=True)
 
+    # Queried features (set by JS query methods)
+    _queried_features = traitlets.Dict({}).tag(sync=True)
+
     def __init__(self, **kwargs):
         """Initialize the MapWidget.
 

--- a/anymap_ts/templates/maplibre.html
+++ b/anymap_ts/templates/maplibre.html
@@ -504,6 +504,304 @@
                     break;
                 }
 
+                case 'setSky': {
+                    const skySpec = {};
+                    if (kwargs.skyColor !== undefined) skySpec['sky-color'] = kwargs.skyColor;
+                    if (kwargs.skyHorizonBlend !== undefined) skySpec['sky-horizon-blend'] = kwargs.skyHorizonBlend;
+                    if (kwargs.horizonColor !== undefined) skySpec['horizon-color'] = kwargs.horizonColor;
+                    if (kwargs.horizonFogBlend !== undefined) skySpec['horizon-fog-blend'] = kwargs.horizonFogBlend;
+                    if (kwargs.fogColor !== undefined) skySpec['fog-color'] = kwargs.fogColor;
+                    if (kwargs.fogGroundBlend !== undefined) skySpec['fog-ground-blend'] = kwargs.fogGroundBlend;
+                    if (kwargs.atmosphereBlend !== undefined) skySpec['atmosphere-blend'] = kwargs.atmosphereBlend;
+                    map.setSky(skySpec);
+                    break;
+                }
+
+                case 'removeSky': {
+                    map.setSky(undefined);
+                    break;
+                }
+
+                case 'addTerrain': {
+                    const terrainSource = kwargs.source;
+                    const terrainExaggeration = kwargs.exaggeration || 1.0;
+                    const terrainSourceId = 'terrain-dem';
+                    if (!map.getSource(terrainSourceId)) {
+                        map.addSource(terrainSourceId, {
+                            type: 'raster-dem',
+                            tiles: [terrainSource.url],
+                            tileSize: 256,
+                            encoding: terrainSource.encoding === 'mapbox' ? 'mapbox' : 'terrarium'
+                        });
+                    }
+                    map.setTerrain({
+                        source: terrainSourceId,
+                        exaggeration: terrainExaggeration
+                    });
+                    break;
+                }
+
+                case 'addImageLayer': {
+                    const imgId = kwargs.id || 'image-' + Date.now();
+                    const imgSourceId = imgId + '-source';
+                    const imgUrl = kwargs.url;
+                    const imgCoords = kwargs.coordinates;
+                    const imgOpacity = kwargs.opacity !== undefined ? kwargs.opacity : 1.0;
+                    if (imgUrl && imgCoords && imgCoords.length === 4) {
+                        if (!map.getSource(imgSourceId)) {
+                            map.addSource(imgSourceId, {
+                                type: 'image',
+                                url: imgUrl,
+                                coordinates: imgCoords
+                            });
+                        }
+                        if (!map.getLayer(imgId)) {
+                            map.addLayer({
+                                id: imgId,
+                                type: 'raster',
+                                source: imgSourceId,
+                                paint: { 'raster-opacity': imgOpacity }
+                            });
+                            addedLayers.push({ id: imgId, name: imgId, type: 'raster' });
+                        }
+                    }
+                    break;
+                }
+
+                case 'setFilter': {
+                    const filterLayerId = kwargs.layerId;
+                    const filterExpr = kwargs.filter || null;
+                    if (filterLayerId && map.getLayer(filterLayerId)) {
+                        map.setFilter(filterLayerId, filterExpr);
+                    }
+                    break;
+                }
+
+                case 'addVideoLayer': {
+                    const vidId = kwargs.id || 'video-' + Date.now();
+                    const vidSourceId = vidId + '-source';
+                    const vidUrls = kwargs.urls;
+                    const vidCoords = kwargs.coordinates;
+                    const vidOpacity = kwargs.opacity !== undefined ? kwargs.opacity : 1.0;
+                    if (vidUrls && vidCoords && vidCoords.length === 4) {
+                        if (!map.getSource(vidSourceId)) {
+                            map.addSource(vidSourceId, {
+                                type: 'video',
+                                urls: vidUrls,
+                                coordinates: vidCoords
+                            });
+                        }
+                        if (!map.getLayer(vidId)) {
+                            map.addLayer({
+                                id: vidId,
+                                type: 'raster',
+                                source: vidSourceId,
+                                paint: { 'raster-opacity': vidOpacity }
+                            });
+                            addedLayers.push({ id: vidId, name: vidId, type: 'raster' });
+                        }
+                    }
+                    break;
+                }
+
+                case 'playVideo': {
+                    const playSourceId = (kwargs.id || '') + '-source';
+                    const playSource = map.getSource(playSourceId);
+                    if (playSource && playSource.play) playSource.play();
+                    break;
+                }
+
+                case 'pauseVideo': {
+                    const pauseSourceId = (kwargs.id || '') + '-source';
+                    const pauseSource = map.getSource(pauseSourceId);
+                    if (pauseSource && pauseSource.pause) pauseSource.pause();
+                    break;
+                }
+
+                case 'addSplitMap': {
+                    const leftLayer = kwargs.leftLayer;
+                    const rightLayer = kwargs.rightLayer;
+                    const splitPos = kwargs.position || 50;
+                    if (!leftLayer || !rightLayer) break;
+
+                    // Hide right layer on primary map
+                    if (map.getLayer(rightLayer)) {
+                        map.setLayoutProperty(rightLayer, 'visibility', 'none');
+                    }
+
+                    // Create overlay container
+                    const mapEl = document.getElementById('map');
+                    const rightContainer = document.createElement('div');
+                    rightContainer.id = 'split-map-right';
+                    rightContainer.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;clip-path:inset(0 0 0 ' + splitPos + '%);pointer-events:none;';
+                    mapEl.appendChild(rightContainer);
+
+                    // Create right map
+                    const rightMap = new maplibregl.Map({
+                        container: rightContainer,
+                        style: state.style,
+                        center: map.getCenter(),
+                        zoom: map.getZoom(),
+                        bearing: map.getBearing(),
+                        pitch: map.getPitch(),
+                        interactive: false,
+                        attributionControl: false
+                    });
+
+                    rightMap.on('load', function() {
+                        // Replay layer-adding calls directly on rightMap
+                        for (const call of (state.js_calls || [])) {
+                            try {
+                                const k = call.kwargs || {};
+                                if (call.method === 'addTileLayer') {
+                                    const tileUrl = call.args[0];
+                                    const tileName = k.name;
+                                    const tileSourceId = tileName + '-source';
+                                    if (!rightMap.getSource(tileSourceId)) {
+                                        rightMap.addSource(tileSourceId, {
+                                            type: 'raster',
+                                            tiles: [tileUrl],
+                                            tileSize: 256,
+                                            attribution: k.attribution || ''
+                                        });
+                                    }
+                                    if (!rightMap.getLayer(tileName)) {
+                                        rightMap.addLayer({
+                                            id: tileName,
+                                            type: 'raster',
+                                            source: tileSourceId
+                                        });
+                                    }
+                                } else if (call.method === 'addBasemap') {
+                                    const bmUrl = call.args[0];
+                                    const bmName = k.name || 'basemap';
+                                    const bmSourceId = 'basemap-' + bmName;
+                                    if (!rightMap.getSource(bmSourceId)) {
+                                        rightMap.addSource(bmSourceId, {
+                                            type: 'raster',
+                                            tiles: [bmUrl],
+                                            tileSize: 256,
+                                            attribution: k.attribution || ''
+                                        });
+                                    }
+                                    if (!rightMap.getLayer(bmSourceId)) {
+                                        rightMap.addLayer({
+                                            id: bmSourceId,
+                                            type: 'raster',
+                                            source: bmSourceId
+                                        });
+                                    }
+                                } else if (call.method === 'addGeoJSON') {
+                                    const gjName = k.name;
+                                    const gjSourceId = gjName + '-source';
+                                    if (!rightMap.getSource(gjSourceId)) {
+                                        rightMap.addSource(gjSourceId, {
+                                            type: 'geojson',
+                                            data: k.data
+                                        });
+                                    }
+                                    if (!rightMap.getLayer(gjName)) {
+                                        const gjType = k.layerType || 'circle';
+                                        rightMap.addLayer({
+                                            id: gjName,
+                                            type: gjType,
+                                            source: gjSourceId,
+                                            paint: k.paint || getDefaultPaint(gjType)
+                                        });
+                                    }
+                                } else if (call.method === 'addImageLayer') {
+                                    const iiId = k.id || 'image-' + Date.now();
+                                    const iiSourceId = iiId + '-source';
+                                    if (k.url && k.coordinates && k.coordinates.length === 4) {
+                                        if (!rightMap.getSource(iiSourceId)) {
+                                            rightMap.addSource(iiSourceId, {
+                                                type: 'image',
+                                                url: k.url,
+                                                coordinates: k.coordinates
+                                            });
+                                        }
+                                        if (!rightMap.getLayer(iiId)) {
+                                            rightMap.addLayer({
+                                                id: iiId,
+                                                type: 'raster',
+                                                source: iiSourceId,
+                                                paint: { 'raster-opacity': k.opacity !== undefined ? k.opacity : 1.0 }
+                                            });
+                                        }
+                                    }
+                                } else if (call.method === 'addVideoLayer') {
+                                    const vvId = k.id || 'video-' + Date.now();
+                                    const vvSourceId = vvId + '-source';
+                                    if (k.urls && k.coordinates && k.coordinates.length === 4) {
+                                        if (!rightMap.getSource(vvSourceId)) {
+                                            rightMap.addSource(vvSourceId, {
+                                                type: 'video',
+                                                urls: k.urls,
+                                                coordinates: k.coordinates
+                                            });
+                                        }
+                                        if (!rightMap.getLayer(vvId)) {
+                                            rightMap.addLayer({
+                                                id: vvId,
+                                                type: 'raster',
+                                                source: vvSourceId,
+                                                paint: { 'raster-opacity': k.opacity !== undefined ? k.opacity : 1.0 }
+                                            });
+                                        }
+                                    }
+                                }
+                            } catch(e) { /* skip failures */ }
+                        }
+                        // Show only the right layer, hide everything else
+                        try {
+                            const allRightLayers = rightMap.getStyle().layers || [];
+                            for (const l of allRightLayers) {
+                                if (l.id === rightLayer) {
+                                    rightMap.setLayoutProperty(l.id, 'visibility', 'visible');
+                                } else {
+                                    try { rightMap.setLayoutProperty(l.id, 'visibility', 'none'); } catch(e) {}
+                                }
+                            }
+                        } catch(e) {}
+                    });
+
+                    // Sync camera
+                    map.on('move', function() {
+                        rightMap.jumpTo({
+                            center: map.getCenter(),
+                            zoom: map.getZoom(),
+                            bearing: map.getBearing(),
+                            pitch: map.getPitch()
+                        });
+                    });
+
+                    // Create slider
+                    const splitSlider = document.createElement('div');
+                    splitSlider.style.cssText = 'position:absolute;top:0;left:' + splitPos + '%;width:4px;height:100%;background:#333;cursor:ew-resize;z-index:10;box-shadow:-1px 0 0 rgba(255,255,255,0.6),1px 0 0 rgba(255,255,255,0.6),0 0 6px rgba(0,0,0,0.5);';
+                    const splitHandle = document.createElement('div');
+                    splitHandle.style.cssText = 'position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:36px;height:36px;border-radius:50%;background:#fff;border:2px solid #333;box-shadow:0 1px 6px rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;font-size:16px;color:#333;font-weight:bold;';
+                    splitHandle.innerHTML = '&#x2194;';
+                    splitSlider.appendChild(splitHandle);
+                    mapEl.appendChild(splitSlider);
+
+                    let splitDragging = false;
+                    splitSlider.addEventListener('pointerdown', function(e) {
+                        splitDragging = true;
+                        splitSlider.setPointerCapture(e.pointerId);
+                        e.preventDefault();
+                    });
+                    window.addEventListener('pointermove', function(e) {
+                        if (!splitDragging) return;
+                        const rect = mapEl.getBoundingClientRect();
+                        const x = e.clientX - rect.left;
+                        const pct = Math.max(0, Math.min(100, (x / rect.width) * 100));
+                        splitSlider.style.left = pct + '%';
+                        rightContainer.style.clipPath = 'inset(0 0 0 ' + pct + '%)';
+                    });
+                    window.addEventListener('pointerup', function() { splitDragging = false; });
+                    break;
+                }
+
                 default:
                     console.log('Unknown method:', method);
             }

--- a/docs/notebooks/feature_query_filter.ipynb
+++ b/docs/notebooks/feature_query_filter.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Feature Query & Filter\n",
+    "\n",
+    "This notebook demonstrates how to programmatically filter layers and query visible features on MapLibre maps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load GeoJSON Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-98.5, 39.8], zoom=3)\n",
+    "m.add_geojson(\n",
+    "    \"https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_0_countries.geojson\",\n",
+    "    name=\"countries\",\n",
+    "    layer_type=\"fill\",\n",
+    "    paint={\n",
+    "        \"fill-color\": \"#627BC1\",\n",
+    "        \"fill-opacity\": 0.5,\n",
+    "        \"fill-outline-color\": \"#333\",\n",
+    "    },\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Apply a Filter\n",
+    "\n",
+    "Show only countries with population greater than 100 million."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.set_filter(\"countries\", [\">\", [\"get\", \"pop_est\"], 100000000])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Change Filter\n",
+    "\n",
+    "Show only European countries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.set_filter(\"countries\", [\"==\", [\"get\", \"continent\"], \"Europe\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clear Filter\n",
+    "\n",
+    "Pass `None` to clear the filter and show all features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.set_filter(\"countries\", None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query Rendered Features\n",
+    "\n",
+    "Query features currently visible in the viewport."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "m.query_rendered_features(layers=[\"countries\"])\n",
+    "time.sleep(1)  # Wait for async response\n",
+    "features = m.queried_features\n",
+    "print(f\"Number of features: {len(features.get('features', []))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query with Filter Expression\n",
+    "\n",
+    "Query only features matching a filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.query_rendered_features(\n",
+    "    layers=[\"countries\"],\n",
+    "    filter_expression=[\"==\", [\"get\", \"continent\"], \"Africa\"],\n",
+    ")\n",
+    "time.sleep(1)\n",
+    "features = m.queried_features\n",
+    "print(f\"African countries in viewport: {len(features.get('features', []))}\")\n",
+    "for f in features.get(\"features\", [])[:5]:\n",
+    "    print(f\"  - {f.get('properties', {}).get('name', 'Unknown')}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/sky_fog.ipynb
+++ b/docs/notebooks/sky_fog.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sky & Fog\n",
+    "\n",
+    "This notebook demonstrates how to add atmospheric sky and fog effects to MapLibre maps.\n",
+    "\n",
+    "MapLibre v5 unifies sky and fog into a single `map.setSky()` API. These effects work best with 3D terrain enabled."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Sky with 3D Terrain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(\n",
+    "    center=[-122.4, 37.8],\n",
+    "    zoom=12,\n",
+    "    pitch=60,\n",
+    "    bearing=-17,\n",
+    "    style=\"https://tiles.openfreemap.org/styles/liberty\",\n",
+    ")\n",
+    "m.add_3d_terrain(exaggeration=1.5)\n",
+    "m.set_sky()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Sky Colors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(\n",
+    "    center=[6.8652, 45.8326],\n",
+    "    zoom=12,\n",
+    "    pitch=70,\n",
+    "    bearing=30,\n",
+    "    style=\"https://tiles.openfreemap.org/styles/liberty\",\n",
+    ")\n",
+    "m2.add_3d_terrain(exaggeration=1.5)\n",
+    "m2.set_sky(\n",
+    "    sky_color=\"#1E90FF\",\n",
+    "    horizon_color=\"#FFD700\",\n",
+    "    fog_color=\"#FFFACD\",\n",
+    "    sky_horizon_blend=0.4,\n",
+    "    horizon_fog_blend=0.6,\n",
+    "    fog_ground_blend=0.8,\n",
+    "    atmosphere_blend=0.9,\n",
+    ")\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sunset Effect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3 = Map(\n",
+    "    center=[-112.1129, 36.1069],\n",
+    "    zoom=13,\n",
+    "    pitch=65,\n",
+    "    bearing=-45,\n",
+    "    style=\"https://tiles.openfreemap.org/styles/liberty\",\n",
+    ")\n",
+    "m3.add_3d_terrain(exaggeration=1.5)\n",
+    "m3.set_sky(\n",
+    "    sky_color=\"#FF6347\",\n",
+    "    horizon_color=\"#FF8C00\",\n",
+    "    fog_color=\"#FFD700\",\n",
+    "    sky_horizon_blend=0.3,\n",
+    "    horizon_fog_blend=0.5,\n",
+    "    fog_ground_blend=0.4,\n",
+    "    atmosphere_blend=0.85,\n",
+    ")\n",
+    "m3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Globe Atmosphere Effect\n",
+    "\n",
+    "Set `atmosphere_blend` close to 1.0 for a globe-like atmosphere halo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m4 = Map(\n",
+    "    center=[0, 20],\n",
+    "    zoom=2,\n",
+    "    pitch=0,\n",
+    "    style=\"https://tiles.openfreemap.org/styles/liberty\",\n",
+    ")\n",
+    "m4.set_sky(\n",
+    "    sky_color=\"#87CEEB\",\n",
+    "    horizon_color=\"#B0E0E6\",\n",
+    "    fog_color=\"#F0F8FF\",\n",
+    "    atmosphere_blend=1.0,\n",
+    ")\n",
+    "m4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Remove Sky"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_sky()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2.to_html(\"sky_fog_example.html\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/split_map.ipynb
+++ b/docs/notebooks/split_map.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Split Map (Swipe/Compare)\n",
+    "\n",
+    "This notebook demonstrates how to compare two map layers side-by-side with a draggable divider.\n",
+    "\n",
+    "The split map view uses two synced MapLibre map instances. The left side shows one layer and the right side shows another, with a draggable slider to control the split position."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare Satellite and OpenStreetMap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-122.4194, 37.7749], zoom=12)\n",
+    "\n",
+    "# Add satellite imagery\n",
+    "m.add_tile_layer(\n",
+    "    \"https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}\",\n",
+    "    name=\"satellite\",\n",
+    "    attribution=\"Google\",\n",
+    ")\n",
+    "\n",
+    "# Add OpenStreetMap\n",
+    "m.add_tile_layer(\n",
+    "    \"https://tile.openstreetmap.org/{z}/{x}/{y}.png\",\n",
+    "    name=\"osm\",\n",
+    "    attribution=\"OpenStreetMap contributors\",\n",
+    ")\n",
+    "\n",
+    "# Enable split map\n",
+    "m.add_split_map(\"satellite\", \"osm\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Split Position\n",
+    "\n",
+    "Set the initial slider position (0-100)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(center=[-73.9857, 40.7484], zoom=13)\n",
+    "\n",
+    "m2.add_tile_layer(\n",
+    "    \"https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}\",\n",
+    "    name=\"satellite\",\n",
+    "    attribution=\"Google\",\n",
+    ")\n",
+    "\n",
+    "m2.add_tile_layer(\n",
+    "    \"https://tile.openstreetmap.org/{z}/{x}/{y}.png\",\n",
+    "    name=\"osm\",\n",
+    "    attribution=\"OpenStreetMap contributors\",\n",
+    ")\n",
+    "\n",
+    "# Start with the slider at 30%\n",
+    "m2.add_split_map(\"satellite\", \"osm\", position=30)\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Remove Split Map\n",
+    "\n",
+    "Return to normal single-view mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_split_map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2.to_html(\"split_map_example.html\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/video_layer.ipynb
+++ b/docs/notebooks/video_layer.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Video Layer\n",
+    "\n",
+    "This notebook demonstrates how to overlay georeferenced video on a MapLibre map.\n",
+    "\n",
+    "Video layers use MapLibre's native `video` source type, which displays a video at specified geographic coordinates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add a Video Layer\n",
+    "\n",
+    "Overlay a drone video on the map at specified geographic coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(\n",
+    "    center=[-122.514426, 37.562984],\n",
+    "    zoom=17,\n",
+    "    bearing=-96,\n",
+    ")\n",
+    "m.add_basemap(\"Esri.WorldImagery\")\n",
+    "m.add_video_layer(\n",
+    "    urls=[\n",
+    "        \"https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4\",\n",
+    "        \"https://static-assets.mapbox.com/mapbox-gl-js/drone.webm\",\n",
+    "    ],\n",
+    "    coordinates=[\n",
+    "        [-122.51596391658498, 37.56238816766053],\n",
+    "        [-122.51467645489949, 37.56410183312965],\n",
+    "        [-122.51309394645498, 37.563391708549425],\n",
+    "        [-122.51423120498498, 37.56161849366671],\n",
+    "    ],\n",
+    "    name=\"drone-video\",\n",
+    "    opacity=0.9,\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Playback Controls\n",
+    "\n",
+    "Control video playback programmatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pause the video\n",
+    "m.pause_video(\"drone-video\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Seek to 5 seconds\n",
+    "m.seek_video(\"drone-video\", 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resume playing\n",
+    "m.play_video(\"drone-video\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Remove Video Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_video_layer(\"drone-video\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a new map with the video layer for export\n",
+    "m2 = Map(\n",
+    "    center=[-122.514426, 37.562984],\n",
+    "    zoom=17,\n",
+    "    bearing=-96,\n",
+    ")\n",
+    "m2.add_video_layer(\n",
+    "    urls=[\n",
+    "        \"https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4\",\n",
+    "        \"https://static-assets.mapbox.com/mapbox-gl-js/drone.webm\",\n",
+    "    ],\n",
+    "    coordinates=[\n",
+    "        [-122.51596391658498, 37.56238816766053],\n",
+    "        [-122.51467645489949, 37.56410183312965],\n",
+    "        [-122.51309394645498, 37.563391708549425],\n",
+    "        [-122.51423120498498, 37.56161849366671],\n",
+    "    ],\n",
+    "    name=\"drone-video\",\n",
+    ")\n",
+    "m2.to_html(\"video_layer_example.html\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/core/BaseMapRenderer.ts
+++ b/src/core/BaseMapRenderer.ts
@@ -196,12 +196,10 @@ export abstract class BaseMapRenderer<TMap> {
     const layers = this.model.get('_layers') || {};
     const entries = Object.entries(layers);
     const basemapEntries = entries.filter(([id, cfg]) => {
-      const config = cfg as Record<string, unknown>;
-      return id.startsWith('basemap-') || config.type === 'raster';
+      return id.startsWith('basemap-') || cfg.type === 'raster';
     });
     const otherEntries = entries.filter(([id, cfg]) => {
-      const config = cfg as Record<string, unknown>;
-      return !(id.startsWith('basemap-') || config.type === 'raster');
+      return !(id.startsWith('basemap-') || cfg.type === 'raster');
     });
     const orderedEntries = [...basemapEntries, ...otherEntries];
     for (const [layerId, layerConfig] of orderedEntries) {

--- a/src/core/StateManager.ts
+++ b/src/core/StateManager.ts
@@ -68,6 +68,19 @@ export class StateManager {
   }
 
   /**
+   * Update layer filter.
+   */
+  setLayerFilter(layerId: string, filter: unknown[] | null): void {
+    const layers = { ...this.model.get('_layers') };
+    if (layers[layerId]) {
+      const { filter: _oldFilter, ...rest } = layers[layerId];
+      layers[layerId] = filter ? { ...rest, filter } : { ...rest };
+      this.model.set('_layers', layers);
+      this.model.save_changes();
+    }
+  }
+
+  /**
    * Get layer state.
    */
   getLayer(layerId: string): LayerState | undefined {
@@ -90,9 +103,11 @@ export class StateManager {
       type: config.type,
       data: config.data,
       url: config.url,
+      urls: config.urls,
       tiles: config.tiles,
       tileSize: config.tileSize,
       attribution: config.attribution,
+      coordinates: config.coordinates,
     };
     this.model.set('_sources', { ...sources, [sourceId]: sourceState });
     this.model.save_changes();

--- a/src/types/anywidget.ts
+++ b/src/types/anywidget.ts
@@ -49,6 +49,7 @@ export interface LayerState {
   source: string;
   paint?: Record<string, unknown>;
   layout?: Record<string, unknown>;
+  filter?: unknown[];
   visible?: boolean;
   opacity?: number;
 }
@@ -60,9 +61,11 @@ export interface SourceState {
   type: string;
   data?: unknown;
   url?: string;
+  urls?: string[];
   tiles?: string[];
   tileSize?: number;
   attribution?: string;
+  coordinates?: number[][];
 }
 
 /**
@@ -92,6 +95,7 @@ export interface MapWidgetModel extends AnyModel {
   get(key: '_sources'): Record<string, SourceState>;
   get(key: '_controls'): Record<string, ControlState>;
   get(key: '_draw_data'): FeatureCollection | null;
+  get(key: '_queried_features'): Record<string, unknown>;
   get(key: 'clicked'): ClickedPoint | null;
   get(key: 'current_bounds'): [number, number, number, number] | null;
   get(key: string): unknown;
@@ -102,6 +106,7 @@ export interface MapWidgetModel extends AnyModel {
   set(key: 'clicked', value: ClickedPoint): void;
   set(key: '_js_events', value: JsEvent[]): void;
   set(key: '_draw_data', value: FeatureCollection): void;
+  set(key: '_queried_features', value: Record<string, unknown>): void;
   set(key: 'current_bounds', value: [number, number, number, number]): void;
   set(key: 'current_center', value: [number, number]): void;
   set(key: 'current_zoom', value: number): void;

--- a/src/types/maplibre.ts
+++ b/src/types/maplibre.ts
@@ -68,12 +68,27 @@ export interface SourceConfig {
   type: SourceType;
   data?: FeatureCollection | Feature | string;
   url?: string;
+  urls?: string[];
   tiles?: string[];
   tileSize?: number;
   attribution?: string;
+  coordinates?: number[][];
   bounds?: [number, number, number, number];
   minzoom?: number;
   maxzoom?: number;
+}
+
+/**
+ * MapLibre sky specification.
+ */
+export interface SkySpecification {
+  'sky-color'?: string;
+  'sky-horizon-blend'?: number;
+  'horizon-color'?: string;
+  'horizon-fog-blend'?: number;
+  'fog-color'?: string;
+  'fog-ground-blend'?: number;
+  'atmosphere-blend'?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds four new MapLibre backend features using native GL JS APIs (no new npm dependencies):

- **Sky & Fog**: `set_sky()` / `remove_sky()` for atmospheric effects, best with 3D terrain
- **Feature Query/Filter**: `set_filter()`, `query_rendered_features()`, `query_source_features()` with `queried_features` property
- **Video Layer**: `add_video_layer()` / `remove_video_layer()` with `play_video()`, `pause_video()`, `seek_video()` controls
- **Split Map (Swipe/Compare)**: `add_split_map()` / `remove_split_map()` with draggable divider using two synced map instances

All features include HTML export support, TypeScript type updates, and state persistence where applicable.

### Files changed

| Area | Files |
|------|-------|
| Python | `anymap_ts/base.py`, `anymap_ts/maplibre.py` |
| TypeScript types | `src/types/anywidget.ts`, `src/types/maplibre.ts` |
| TypeScript core | `src/core/BaseMapRenderer.ts`, `src/core/StateManager.ts` |
| TypeScript renderer | `src/maplibre/MapLibreRenderer.ts` |
| HTML export | `anymap_ts/templates/maplibre.html` |
| Notebooks | `docs/notebooks/sky_fog.ipynb`, `docs/notebooks/feature_query_filter.ipynb`, `docs/notebooks/video_layer.ipynb`, `docs/notebooks/split_map.ipynb` |

## Test plan

- [ ] `npm run build` and `npm run typecheck` pass
- [ ] `pre-commit run --all-files` passes
- [ ] Sky/fog renders with 3D terrain in notebook and HTML export
- [ ] Filter shows/hides features; query returns feature data to Python
- [ ] Video plays at correct geographic location with play/pause/seek
- [ ] Split map shows two different layers with functional draggable divider
- [ ] HTML export works correctly for all features (especially split map showing distinct left/right layers)