### PR TITLE
Add colorbar, search, measure, print, and FlatGeobuf features

### DIFF
--- a/anymap_ts/templates/maplibre.html
+++ b/anymap_ts/templates/maplibre.html
@@ -352,6 +352,100 @@
                     break;
                 }
 
+                case 'addColorbar': {
+                    const cbId = kwargs.colorbarId || 'colorbar-0';
+                    const cbColormap = kwargs.colormap || 'viridis';
+                    const cbVmin = kwargs.vmin !== undefined ? kwargs.vmin : 0;
+                    const cbVmax = kwargs.vmax !== undefined ? kwargs.vmax : 1;
+                    const cbLabel = kwargs.label || '';
+                    const cbUnits = kwargs.units || '';
+                    const cbOrientation = kwargs.orientation || 'horizontal';
+                    const cbPosition = kwargs.position || 'bottom-right';
+                    const cbBarThickness = kwargs.barThickness || 20;
+                    const cbBarLength = kwargs.barLength || 250;
+                    const cbOpacity = kwargs.opacity !== undefined ? kwargs.opacity : 1.0;
+
+                    // Colormap gradients (CSS approximations)
+                    const colormapGradients = {
+                        'viridis': 'linear-gradient(to right, #440154, #482878, #3e4989, #31688e, #26828e, #1f9e89, #35b779, #6ece58, #b5de2b, #fde725)',
+                        'plasma': 'linear-gradient(to right, #0d0887, #46039f, #7201a8, #9c179e, #bd3786, #d8576b, #ed7953, #fb9f3a, #fdca26, #f0f921)',
+                        'inferno': 'linear-gradient(to right, #000004, #1b0c41, #4a0c6b, #781c6d, #a52c60, #cf4446, #ed6925, #fb9b06, #f7d13d, #fcffa4)',
+                        'magma': 'linear-gradient(to right, #000004, #180f3d, #440f76, #721f81, #9e2f7f, #cd4071, #f1605d, #fd9668, #feca8d, #fcfdbf)',
+                        'cividis': 'linear-gradient(to right, #00224e, #123570, #1f4b86, #2c6291, #3c7a91, #4f928c, #65ab7c, #84c267, #abd94f, #fdea45)',
+                        'coolwarm': 'linear-gradient(to right, #3b4cc0, #6788ee, #9abbff, #c9d7ef, #eddad5, #f7a789, #e36c51, #b40426)',
+                        'terrain': 'linear-gradient(to right, #333399, #00b2b2, #00ff00, #cccc00, #cc6600, #993300, #ffffff)',
+                        'jet': 'linear-gradient(to right, #00007f, #0000ff, #007fff, #00ffff, #7fff7f, #ffff00, #ff7f00, #ff0000, #7f0000)',
+                        'turbo': 'linear-gradient(to right, #30123b, #4662d7, #36aaf9, #1ae4b6, #72fe5e, #c8ef34, #faba39, #f66b19, #ca2a04, #7a0403)',
+                        'hot': 'linear-gradient(to right, #000000, #e60000, #ffa500, #ffff00, #ffffff)',
+                        'cool': 'linear-gradient(to right, #00ffff, #ff00ff)',
+                        'gray': 'linear-gradient(to right, #000000, #ffffff)',
+                        'rainbow': 'linear-gradient(to right, #ff0000, #ff7f00, #ffff00, #00ff00, #0000ff, #4b0082, #8f00ff)',
+                    };
+                    const isVertical = cbOrientation === 'vertical';
+                    const gradientDir = isVertical ? 'to top' : 'to right';
+                    let gradient = (colormapGradients[cbColormap] || colormapGradients['viridis']).replace('to right', gradientDir);
+
+                    // Build colorbar element
+                    const cbDiv = document.createElement('div');
+                    cbDiv.id = cbId;
+                    cbDiv.className = 'maplibregl-ctrl';
+                    cbDiv.style.cssText = `
+                        background: rgba(255, 255, 255, ${cbOpacity});
+                        padding: 8px 12px;
+                        border-radius: 4px;
+                        box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                        font-size: 11px;
+                    `;
+
+                    if (cbLabel) {
+                        const labelEl = document.createElement('div');
+                        labelEl.style.cssText = 'font-weight: bold; margin-bottom: 4px; font-size: 12px; text-align: center;';
+                        labelEl.textContent = cbLabel;
+                        cbDiv.appendChild(labelEl);
+                    }
+
+                    const barEl = document.createElement('div');
+                    barEl.style.cssText = isVertical
+                        ? `width: ${cbBarThickness}px; height: ${cbBarLength}px; background: ${gradient}; border: 1px solid #ccc; margin: 0 auto;`
+                        : `width: ${cbBarLength}px; height: ${cbBarThickness}px; background: ${gradient}; border: 1px solid #ccc;`;
+                    cbDiv.appendChild(barEl);
+
+                    // Tick labels
+                    const tickCount = 5;
+                    const ticksDiv = document.createElement('div');
+                    ticksDiv.style.cssText = isVertical
+                        ? `display: flex; flex-direction: column-reverse; justify-content: space-between; height: ${cbBarLength}px; position: absolute; right: -30px; top: 0; font-size: 10px;`
+                        : `display: flex; justify-content: space-between; margin-top: 2px; font-size: 10px;`;
+                    for (let i = 0; i < tickCount; i++) {
+                        const val = cbVmin + (cbVmax - cbVmin) * i / (tickCount - 1);
+                        const tickEl = document.createElement('span');
+                        tickEl.textContent = val.toFixed(val % 1 === 0 ? 0 : 1);
+                        ticksDiv.appendChild(tickEl);
+                    }
+                    if (!isVertical) {
+                        cbDiv.appendChild(ticksDiv);
+                    }
+
+                    if (cbUnits) {
+                        const unitsEl = document.createElement('div');
+                        unitsEl.style.cssText = 'text-align: center; margin-top: 2px; font-size: 10px; color: #666;';
+                        unitsEl.textContent = cbUnits;
+                        cbDiv.appendChild(unitsEl);
+                    }
+
+                    // Add to map control container
+                    const cbPosClass = 'maplibregl-ctrl-' + cbPosition;
+                    let cbContainer = document.querySelector('.' + cbPosClass);
+                    if (!cbContainer) {
+                        cbContainer = document.createElement('div');
+                        cbContainer.className = 'maplibregl-ctrl-' + cbPosition.split('-')[0] + ' ' + cbPosClass;
+                        document.querySelector('.maplibregl-control-container').appendChild(cbContainer);
+                    }
+                    cbContainer.insertBefore(cbDiv, cbContainer.firstChild);
+                    break;
+                }
+
                 case 'flyTo': {
                     map.flyTo({
                         center: [args[0], args[1]],

--- a/docs/notebooks/colorbar.ipynb
+++ b/docs/notebooks/colorbar.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Colorbar\n",
+    "\n",
+    "This notebook demonstrates how to add continuous gradient colorbars to MapLibre maps using the `Colorbar` component from maplibre-gl-components."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Basic Colorbar with COG Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-120, 38], zoom=6)\n",
+    "m.add_cog_layer(\n",
+    "    \"https://data.source.coop/giswqs/opengeos/dem_90m.tif\",\n",
+    "    name=\"dem\",\n",
+    ")\n",
+    "m.add_colorbar(\n",
+    "    colormap=\"terrain\",\n",
+    "    vmin=0,\n",
+    "    vmax=4000,\n",
+    "    label=\"Elevation\",\n",
+    "    units=\"m\",\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Different Colormaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(center=[0, 20], zoom=2)\n",
+    "m2.add_colorbar(\n",
+    "    colormap=\"viridis\",\n",
+    "    vmin=-30,\n",
+    "    vmax=40,\n",
+    "    label=\"Temperature\",\n",
+    "    units=\"\\u00b0C\",\n",
+    "    position=\"bottom-left\",\n",
+    ")\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Vertical Colorbar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3 = Map(center=[-100, 40], zoom=4)\n",
+    "m3.add_colorbar(\n",
+    "    colormap=\"plasma\",\n",
+    "    vmin=0,\n",
+    "    vmax=100,\n",
+    "    label=\"Index\",\n",
+    "    orientation=\"vertical\",\n",
+    "    position=\"bottom-right\",\n",
+    ")\n",
+    "m3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Update Colorbar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.update_colorbar(vmin=100, vmax=3000, colormap=\"inferno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Remove Colorbar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_colorbar()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/flatgeobuf.ipynb
+++ b/docs/notebooks/flatgeobuf.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# FlatGeobuf Layer\n",
+    "\n",
+    "This notebook demonstrates how to load and display FlatGeobuf files on MapLibre maps. FlatGeobuf is a cloud-native vector format that supports streaming reads."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Load FlatGeobuf from URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-100, 40], zoom=4)\n",
+    "m.add_flatgeobuf(\n",
+    "    \"https://flatgeobuf.org/test/data/UScounties.fgb\",\n",
+    "    name=\"counties\",\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Custom Styling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(center=[-100, 40], zoom=4)\n",
+    "m2.add_flatgeobuf(\n",
+    "    \"https://flatgeobuf.org/test/data/UScounties.fgb\",\n",
+    "    name=\"counties-styled\",\n",
+    "    paint={\n",
+    "        \"fill-color\": \"#088\",\n",
+    "        \"fill-opacity\": 0.4,\n",
+    "        \"fill-outline-color\": \"#333\",\n",
+    "    },\n",
+    ")\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Remove FlatGeobuf Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_flatgeobuf(\"counties\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/measure.ipynb
+++ b/docs/notebooks/measure.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Measurement Tools\n",
+    "\n",
+    "This notebook demonstrates how to add measurement tools for distances and areas on MapLibre maps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Distance Measurement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-122.4, 37.8], zoom=10)\n",
+    "m.add_measure_control(\n",
+    "    position=\"top-right\",\n",
+    "    default_mode=\"distance\",\n",
+    "    distance_unit=\"kilometers\",\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Area Measurement with Custom Colors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(center=[-100, 40], zoom=4)\n",
+    "m2.add_measure_control(\n",
+    "    position=\"top-right\",\n",
+    "    default_mode=\"area\",\n",
+    "    area_unit=\"square-miles\",\n",
+    "    line_color=\"#e74c3c\",\n",
+    "    fill_color=\"rgba(231, 76, 60, 0.2)\",\n",
+    ")\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Remove Measure Control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_measure_control()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/print_control.ipynb
+++ b/docs/notebooks/print_control.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Print / Export Control\n",
+    "\n",
+    "This notebook demonstrates how to add a print/export control for saving the map view as PNG, JPEG, or PDF."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Basic Print Control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-122.4, 37.8], zoom=10)\n",
+    "m.add_print_control(position=\"top-right\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Print Control with Layers and Options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(\n",
+    "    center=[-112.1, 36.1],\n",
+    "    zoom=13,\n",
+    "    pitch=60,\n",
+    "    bearing=-17,\n",
+    "    style=\"https://tiles.openfreemap.org/styles/liberty\",\n",
+    ")\n",
+    "m2.add_3d_terrain(exaggeration=1.5)\n",
+    "m2.add_print_control(\n",
+    "    position=\"top-right\",\n",
+    "    format=\"png\",\n",
+    "    filename=\"grand-canyon\",\n",
+    "    include_north_arrow=True,\n",
+    "    include_scale_bar=True,\n",
+    ")\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Remove Print Control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_print_control()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/search_control.ipynb
+++ b/docs/notebooks/search_control.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Search Control\n",
+    "\n",
+    "This notebook demonstrates how to add a search/geocoder control to MapLibre maps. The search control uses OpenStreetMap Nominatim for geocoding."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Basic Search Control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-100, 40], zoom=4)\n",
+    "m.add_search_control(position=\"top-left\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Expanded Search with Custom Options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = Map(center=[0, 20], zoom=2)\n",
+    "m2.add_search_control(\n",
+    "    position=\"top-left\",\n",
+    "    placeholder=\"Find a location...\",\n",
+    "    collapsed=False,\n",
+    "    fly_to_zoom=12,\n",
+    "    show_marker=True,\n",
+    ")\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Remove Search Control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.remove_search_control()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/core/BaseMapRenderer.ts
+++ b/src/core/BaseMapRenderer.ts
@@ -193,8 +193,16 @@ export abstract class BaseMapRenderer<TMap> {
 
     // Then restore layers, ensuring correct z-order:
     // Basemap (raster) layers must be added first so they sit below vector layers.
+    // Skip non-native MapLibre layer types (deck.gl, markers, etc.) — they are
+    // restored via js_calls replay, not through addLayer.
+    const NATIVE_LAYER_TYPES = new Set([
+      'fill', 'line', 'symbol', 'circle', 'heatmap',
+      'fill-extrusion', 'raster', 'hillshade', 'color-relief', 'background',
+    ]);
     const layers = this.model.get('_layers') || {};
-    const entries = Object.entries(layers);
+    const entries = Object.entries(layers).filter(([, cfg]) => {
+      return NATIVE_LAYER_TYPES.has(cfg.type);
+    });
     const basemapEntries = entries.filter(([id, cfg]) => {
       return id.startsWith('basemap-') || cfg.type === 'raster';
     });


### PR DESCRIPTION
## Summary

- **Colorbar**: Add `add_colorbar()`, `remove_colorbar()`, `update_colorbar()` using `Colorbar` from maplibre-gl-components. Supports all colormaps (viridis, terrain, plasma, etc.), horizontal/vertical orientation, and custom tick configuration. Also renders in standalone HTML export.
- **Search Control**: Add `add_search_control()`, `remove_search_control()` using `SearchControl` from maplibre-gl-components. Provides Nominatim geocoding with autocomplete, fly-to, and optional result markers.
- **Measure Control**: Add `add_measure_control()`, `remove_measure_control()` using `MeasureControl` from maplibre-gl-components. Supports distance and area measurement modes with configurable units and colors.
- **Print/Export Control**: Add `add_print_control()`, `remove_print_control()` using `PrintControl` from maplibre-gl-components. Supports PNG, JPEG, and PDF export with optional north arrow and scale bar.
- **FlatGeobuf Layer**: Add `add_flatgeobuf()`, `remove_flatgeobuf()` for streaming cloud-native FlatGeobuf vector data via `fetch` + `ReadableStream` deserialization. Auto-infers layer type and fits bounds.
- **Bug fix**: Fix `restoreState()` in `BaseMapRenderer.ts` to skip non-native MapLibre layer types (cog, zarr, marker, lidar, flatgeobuf, video, etc.) that were incorrectly passed to `map.addLayer()` causing errors like `"cog" found` when expected native types.

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] `npm run typecheck` passes
- [ ] `pre-commit run --all-files` passes
- [ ] Test `colorbar.ipynb` — colorbar renders with COG layer
- [ ] Test `search_control.ipynb` — search and fly-to work
- [ ] Test `measure.ipynb` — distance and area measurements work
- [ ] Test `print_control.ipynb` — map exports as PNG/JPEG
- [ ] Test `flatgeobuf.ipynb` — US counties load and render
- [ ] Test HTML export for colorbar (`m.to_html()`)