### PR TITLE
Add pip install cell to all notebook examples

### DIFF
--- a/docs/cesium/cesium.ipynb
+++ b/docs/cesium/cesium.ipynb
@@ -27,6 +27,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import CesiumMap\n",
     "\n",
     "# Create a Cesium globe (uses CESIUM_TOKEN env var)\n",

--- a/docs/deckgl/bitmap_layer.ipynb
+++ b/docs/deckgl/bitmap_layer.ipynb
@@ -23,6 +23,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },

--- a/docs/deckgl/column_layer.ipynb
+++ b/docs/deckgl/column_layer.ipynb
@@ -23,6 +23,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import random\n",
     "from anymap_ts import DeckGLMap"
    ]

--- a/docs/deckgl/contour_layer.ipynb
+++ b/docs/deckgl/contour_layer.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/deckgl/deckgl.ipynb
+++ b/docs/deckgl/deckgl.ipynb
@@ -25,6 +25,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap\n",
     "\n",
     "# Create a DeckGL map\n",

--- a/docs/deckgl/geohash_layer.ipynb
+++ b/docs/deckgl/geohash_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define geohash data"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with geohash layer"
@@ -70,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -100,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/geojson_layer.ipynb
+++ b/docs/deckgl/geojson_layer.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/deckgl/great_circle_layer.ipynb
+++ b/docs/deckgl/great_circle_layer.ipynb
@@ -23,6 +23,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },

--- a/docs/deckgl/gridcell_layer.ipynb
+++ b/docs/deckgl/gridcell_layer.ipynb
@@ -26,13 +26,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import random\n",
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Generate grid cell data"
@@ -41,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with grid cell layer"
@@ -80,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -111,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/h3_cluster_layer.ipynb
+++ b/docs/deckgl/h3_cluster_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define H3 cluster data"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with H3 cluster layer"
@@ -76,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -106,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/h3_hexagon_layer.ipynb
+++ b/docs/deckgl/h3_hexagon_layer.ipynb
@@ -23,6 +23,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },

--- a/docs/deckgl/heatmap_layer.ipynb
+++ b/docs/deckgl/heatmap_layer.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Heatmap Layer"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Heatmap with Custom Color Range"
@@ -73,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Heatmap with Weighted Points"
@@ -110,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Heatmap with Layer Control"
@@ -150,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Using the Generic add_deckgl_layer Method"
@@ -177,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -206,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/hexagon_layer.ipynb
+++ b/docs/deckgl/hexagon_layer.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Hexagon Layer"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Flat Hexagon Layer (No Extrusion)"
@@ -73,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Custom Color Range"
@@ -101,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Hexagon Layer with Layer Control"
@@ -143,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Using the Generic add_deckgl_layer Method"
@@ -172,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -202,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/icon_layer.ipynb
+++ b/docs/deckgl/icon_layer.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/deckgl/mvt_layer.ipynb
+++ b/docs/deckgl/mvt_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Create a map with MVT layer"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -72,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/polygon_layer.ipynb
+++ b/docs/deckgl/polygon_layer.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/deckgl/quadkey_layer.ipynb
+++ b/docs/deckgl/quadkey_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define quadkey data"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with quadkey layer"
@@ -68,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -98,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/s2_layer.ipynb
+++ b/docs/deckgl/s2_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define S2 cell data"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with S2 layer"
@@ -68,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -98,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/scatterplot_layer.ipynb
+++ b/docs/deckgl/scatterplot_layer.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Scatterplot Layer"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Scatterplot with Size Based on Value"
@@ -74,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Multiple Scatterplot Layers with Layer Control"
@@ -107,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +153,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Using the Generic add_deckgl_layer Method"
@@ -152,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -184,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/scenegraph_layer.ipynb
+++ b/docs/deckgl/scenegraph_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define model positions"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with scenegraph layer"
@@ -65,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -95,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/simplemesh_layer.ipynb
+++ b/docs/deckgl/simplemesh_layer.ipynb
@@ -31,12 +31,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define mesh data positions"
@@ -45,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with ScenegraphLayer\n",
@@ -72,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML\n",
@@ -107,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/solidpolygon_layer.ipynb
+++ b/docs/deckgl/solidpolygon_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Define polygon data (building footprints)"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Create map with solid polygon layer"
@@ -89,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -119,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/terrain_layer.ipynb
+++ b/docs/deckgl/terrain_layer.ipynb
@@ -23,6 +23,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },

--- a/docs/deckgl/text_layer.ipynb
+++ b/docs/deckgl/text_layer.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/deckgl/tile3d_layer.ipynb
+++ b/docs/deckgl/tile3d_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Create a map with 3D Tiles"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -70,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/tile_layer.ipynb
+++ b/docs/deckgl/tile_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Create a map with a tile layer"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -69,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/trips_layer.ipynb
+++ b/docs/deckgl/trips_layer.ipynb
@@ -26,8 +26,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Trips Layer"
@@ -36,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Trips Layer with Different Colors"
@@ -105,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Using the Generic add_deckgl_layer Method"
@@ -154,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Trips Layer with Layer Control"
@@ -187,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -216,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/deckgl/wms_layer.ipynb
+++ b/docs/deckgl/wms_layer.ipynb
@@ -26,12 +26,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import DeckGLMap"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Create a map with WMS layer"
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -68,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/keplergl/keplergl.ipynb
+++ b/docs/keplergl/keplergl.ipynb
@@ -27,6 +27,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import KeplerGLMap\n",
     "import pandas as pd\n",
     "\n",

--- a/docs/leaflet/leaflet.ipynb
+++ b/docs/leaflet/leaflet.ipynb
@@ -25,6 +25,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import LeafletMap\n",
     "\n",
     "# Create a Leaflet map\n",

--- a/docs/mapbox/mapbox.ipynb
+++ b/docs/mapbox/mapbox.ipynb
@@ -25,6 +25,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "from anymap_ts import MapboxMap\n",
     "\n",

--- a/docs/maplibre/arc_layer.ipynb
+++ b/docs/maplibre/arc_layer.ipynb
@@ -24,6 +24,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/buildings_3d.ipynb
+++ b/docs/maplibre/buildings_3d.ipynb
@@ -20,6 +20,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/choropleth.ipynb
+++ b/docs/maplibre/choropleth.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/clustering.ipynb
+++ b/docs/maplibre/clustering.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/cog_layer.ipynb
+++ b/docs/maplibre/cog_layer.ipynb
@@ -22,8 +22,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## MapLibre Example\n",
@@ -34,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## DeckGL Example\n",
@@ -65,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Mapbox Example\n",
@@ -98,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Configuration Options\n",
@@ -144,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "## About the Dataset\n",
@@ -168,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/colorbar.ipynb
+++ b/docs/maplibre/colorbar.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Colorbar with COG Layer"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Different Colormaps"
@@ -62,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Vertical Colorbar"
@@ -89,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Update Colorbar"
@@ -116,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Remove Colorbar"
@@ -134,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/control_grid.ipynb
+++ b/docs/maplibre/control_grid.ipynb
@@ -25,6 +25,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import MapLibreMap"
    ]
   },

--- a/docs/maplibre/feature_query_filter.ipynb
+++ b/docs/maplibre/feature_query_filter.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/flatgeobuf.ipynb
+++ b/docs/maplibre/flatgeobuf.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Load FlatGeobuf from URL"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Custom Styling"
@@ -55,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Remove FlatGeobuf Layer"
@@ -83,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/image_overlay.ipynb
+++ b/docs/maplibre/image_overlay.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/layer_management.ipynb
+++ b/docs/maplibre/layer_management.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/lidar_layer.ipynb
+++ b/docs/maplibre/lidar_layer.ipynb
@@ -27,8 +27,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic LiDAR with MapLibre (Interactive Control Panel)"
@@ -37,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Programmatic LiDAR Loading from URL\n",
@@ -73,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Color Scheme: Classification with Layer Control\n",
@@ -117,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Color Scheme: Intensity\n",
@@ -158,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Change Color Scheme Dynamically"
@@ -193,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Adjust Point Size and Opacity"
@@ -234,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Remove LiDAR Layer"
@@ -276,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Export to HTML"
@@ -295,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/maplibre.ipynb
+++ b/docs/maplibre/maplibre.ipynb
@@ -16,6 +16,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import Map\n",
     "\n",
     "m = Map(center=[-122.4, 37.8], zoom=10)\n",
@@ -28,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/maplibre_heatmap.ipynb
+++ b/docs/maplibre/maplibre_heatmap.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/markers.ipynb
+++ b/docs/maplibre/markers.ipynb
@@ -26,6 +26,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/measure.ipynb
+++ b/docs/maplibre/measure.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Distance Measurement"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Area Measurement with Custom Colors"
@@ -56,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Remove Measure Control"
@@ -82,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/pmtiles_layer.ipynb
+++ b/docs/maplibre/pmtiles_layer.ipynb
@@ -41,6 +41,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import Map"
    ]
   },
@@ -277,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/pointcloud_layer.ipynb
+++ b/docs/maplibre/pointcloud_layer.ipynb
@@ -24,6 +24,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/popups.ipynb
+++ b/docs/maplibre/popups.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/print_control.ipynb
+++ b/docs/maplibre/print_control.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Print Control"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Print Control with Layers and Options"
@@ -52,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Remove Print Control"
@@ -85,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/route_animation.ipynb
+++ b/docs/maplibre/route_animation.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/search_control.ipynb
+++ b/docs/maplibre/search_control.ipynb
@@ -20,8 +20,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Search Control"
@@ -30,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Expanded Search with Custom Options"
@@ -52,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Remove Search Control"
@@ -78,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/sky_fog.ipynb
+++ b/docs/maplibre/sky_fog.ipynb
@@ -20,6 +20,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/split_map.ipynb
+++ b/docs/maplibre/split_map.ipynb
@@ -20,6 +20,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/terrain_3d.ipynb
+++ b/docs/maplibre/terrain_3d.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/to_html.ipynb
+++ b/docs/maplibre/to_html.ipynb
@@ -18,6 +18,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/ui_controls.ipynb
+++ b/docs/maplibre/ui_controls.ipynb
@@ -27,6 +27,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import MapLibreMap"
    ]
   },

--- a/docs/maplibre/video_layer.ipynb
+++ b/docs/maplibre/video_layer.ipynb
@@ -20,6 +20,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/maplibre/zarr_layer.ipynb
+++ b/docs/maplibre/zarr_layer.ipynb
@@ -27,8 +27,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Basic Example: 4D Climate Pyramid\n",
@@ -39,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Update Layer Properties\n",
@@ -93,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Ocean Temperature (Zarr v3)\n",
@@ -145,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Burn Probability over CONUS\n",
@@ -193,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Configuration Options\n",
@@ -262,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Sample Datasets\n",
@@ -279,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/openlayers/openlayers.ipynb
+++ b/docs/openlayers/openlayers.ipynb
@@ -25,6 +25,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import OpenLayersMap\n",
     "\n",
     "# Create an OpenLayers map\n",

--- a/docs/potree/potree.ipynb
+++ b/docs/potree/potree.ipynb
@@ -27,6 +27,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# %pip install -U anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from anymap_ts import PotreeViewer\n",
     "\n",
     "# Create a Potree viewer\n",


### PR DESCRIPTION
## Summary
- Added a `# %pip install -U anymap-ts` code cell to all 62 notebook examples
- The install cell is placed right after the Colab/Notebook.link badge cell

## Test plan
- [ ] Verify notebooks render correctly in the docs site
- [ ] Verify the install cell appears after badges in Colab