### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/anymap_ts/_version.py
+++ b/anymap_ts/_version.py
@@ -1,3 +1,3 @@
 """Version information for anymap-ts."""
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anymap-ts",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "TypeScript frontend for anymap-ts interactive maps",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump Python version (`anymap_ts/_version.py`) from 0.7.1 to 0.8.0
- Bump TypeScript version (`package.json`) from 0.7.1 to 0.8.0

## Changes since 0.7.1
- Reorganized notebook examples by backend (#86)
- Added Colab and Notebook.link badges to all notebooks (#86)
- Added pip install cell to all notebook examples (#87)