### PR TITLE
Update Leaflet default controls and fix marker icons

### DIFF
--- a/anymap_ts/leaflet.py
+++ b/anymap_ts/leaflet.py
@@ -135,7 +135,11 @@ class LeafletMap(MapWidget):
 
         # Add default controls
         if controls is None:
-            controls = {"zoom": True, "scale": True}
+            controls = {
+                "scale": {"position": "bottom-left"},
+                "attribution": {"position": "bottom-right"},
+                "layers": {"position": "top-right"},
+            }
 
         for control_name, config in controls.items():
             if config:

--- a/docs/leaflet/leaflet.ipynb
+++ b/docs/leaflet/leaflet.ipynb
@@ -39,6 +39,7 @@
     "# Create a Leaflet map\n",
     "m = LeafletMap(center=[-122.4, 37.8], zoom=10)\n",
     "m.add_basemap(\"OpenStreetMap\")\n",
+    "m.add_control(\"zoom\", position=\"top-right\")\n",
     "m"
    ]
   },
@@ -91,16 +92,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add controls\n",
-    "m.add_control(\"scale\", position=\"bottom-left\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Export to HTML\n",
     "m.to_html(\"leaflet_example.html\")"
    ]
@@ -108,13 +99,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/src/leaflet/index.ts
+++ b/src/leaflet/index.ts
@@ -7,6 +7,24 @@ import type { AnyModel } from '@anywidget/types';
 
 // Import Leaflet CSS
 import 'leaflet/dist/leaflet.css';
+import './leaflet-overrides.css';
+
+// Fix Leaflet default marker icons when bundled (esbuild inlines PNGs as data URLs)
+// @ts-ignore - Import as data URL via esbuild loader
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+// @ts-ignore
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+// @ts-ignore
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+import * as L from 'leaflet/dist/leaflet-src.esm.js';
+
+// @ts-ignore - Override prototype to fix icon paths for bundled builds
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+});
 
 /**
  * Store renderer reference on element for cleanup and multi-cell support.

--- a/src/leaflet/leaflet-overrides.css
+++ b/src/leaflet/leaflet-overrides.css
@@ -1,0 +1,11 @@
+/* Match layer control toggle size to zoom control buttons */
+.leaflet-control-layers-toggle {
+  width: 26px;
+  height: 26px;
+  background-size: 16px 16px;
+}
+.leaflet-touch .leaflet-control-layers-toggle {
+  width: 30px;
+  height: 30px;
+  background-size: 20px 20px;
+}


### PR DESCRIPTION
## Summary
- Remove zoom control from Leaflet defaults; add scale (bottom-left), attribution (bottom-right), and layer control (top-right)
- Fix broken default marker icons in bundled builds by inlining Leaflet PNGs as data URLs via esbuild
- Make layer control dynamic — layers are registered as they are added/removed instead of only at init time
- Size layer control toggle to match zoom control buttons
- Remove redundant `add_control("scale")` call from notebook

## Test plan
- [ ] Open `docs/leaflet/leaflet.ipynb`, restart kernel, run all cells
- [ ] Verify no default zoom control; scale in bottom-left; attribution in bottom-right; layer control in top-right
- [ ] Verify markers display correct pin icons (no broken images)
- [ ] Verify layer control lists basemap and overlay layers
- [ ] Verify layer control toggle icon matches zoom button size