### PR TITLE
Fix OpenLayers duplicate zoom controls, laggy zoom, and missing CSS

### DIFF
--- a/anymap_ts/openlayers.py
+++ b/anymap_ts/openlayers.py
@@ -35,8 +35,9 @@ class OpenLayersMap(MapWidget):
         >>> m
     """
 
-    # ESM module for frontend
+    # ESM module and CSS for frontend
     _esm = STATIC_DIR / "openlayers.js"
+    _css = STATIC_DIR / "openlayers.css"
 
     # OpenLayers-specific traits
     projection = traitlets.Unicode("EPSG:3857").tag(sync=True)

--- a/anymap_ts/templates/openlayers.html
+++ b/anymap_ts/templates/openlayers.html
@@ -30,7 +30,7 @@
                 zoom: state.zoom,
                 rotation: state.rotation || 0
             }),
-            controls: ol.control.defaults.defaults({ attribution: false })
+            controls: []
         });
 
         // Replay JS calls


### PR DESCRIPTION
## Summary
- Remove default controls from OL map initialization (`controls: []`) since Python adds controls via `addControl` calls — this was causing **duplicate zoom controls**
- Add `isSyncingFromView` guard flag to break the view↔model bidirectional sync feedback loop that caused **laggy/jerky zoom animations**
- Add missing `_css` attribute to `OpenLayersMap` widget so the bundled OpenLayers CSS is loaded, fixing **unstyled controls**
- Set explicit `font-size: 16px` on the map container so em-based OL control buttons render at a proper size in Jupyter/VS Code

## Test plan
- [ ] Open the OpenLayers notebook and verify only one set of zoom controls appears
- [ ] Zoom in/out with scroll wheel and verify smooth animation
- [ ] Verify zoom +/- buttons are properly styled and sized
- [ ] Test `m.to_html()` export still works correctly