### PR TITLE
Update CDN versions and fix control grid HTML export

### DIFF
--- a/anymap_ts/maplibre.py
+++ b/anymap_ts/maplibre.py
@@ -3235,6 +3235,7 @@ class MapLibreMap(MapWidget):
         gap: int = 2,
         basemap_style_url: Optional[str] = None,
         exclude_layers: Optional[List[str]] = None,
+        bookmark_options: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """Add a ControlGrid with all default tools or a custom subset.
@@ -3268,6 +3269,11 @@ class MapLibreMap(MapWidget):
             exclude_layers: Layer ID patterns to exclude from SwipeControl
                 (e.g., 'measure-*', 'gl-draw-*'). If None, sensible defaults
                 are applied.
+            bookmark_options: Options for the bookmark control, such as
+                preloaded bookmarks. Keys use camelCase to match the JS API.
+                Example: ``{"bookmarks": [{"id": "nyc", "name": "New York",
+                "lng": -74.006, "lat": 40.7128, "zoom": 12, "pitch": 0,
+                "bearing": 0, "createdAt": 0}]}``.
             **kwargs: Additional ControlGrid options.
 
         Example:
@@ -3302,6 +3308,8 @@ class MapLibreMap(MapWidget):
             js_kwargs["basemapStyleUrl"] = basemap_style_url
         if exclude_layers is not None:
             js_kwargs["excludeLayers"] = exclude_layers
+        if bookmark_options is not None:
+            js_kwargs["bookmarkOptions"] = bookmark_options
 
         self.call_js_method("addControlGrid", **js_kwargs)
         # Save full config for HTML export
@@ -3318,6 +3326,14 @@ class MapLibreMap(MapWidget):
             control_config["rows"] = rows
         if columns is not None:
             control_config["columns"] = columns
+        if title:
+            control_config["title"] = title
+        if basemap_style_url is not None:
+            control_config["basemapStyleUrl"] = basemap_style_url
+        if exclude_layers is not None:
+            control_config["excludeLayers"] = exclude_layers
+        if bookmark_options is not None:
+            control_config["bookmarkOptions"] = bookmark_options
         self._controls = {
             **self._controls,
             "control-grid": control_config,

--- a/anymap_ts/templates/maplibre.html
+++ b/anymap_ts/templates/maplibre.html
@@ -10,9 +10,9 @@
     <!-- PMTiles -->
     <script src="https://unpkg.com/pmtiles@3.0.8/dist/pmtiles.js"></script>
     <!-- maplibre-gl-layer-control CSS -->
-    <link href="https://unpkg.com/maplibre-gl-layer-control@0.13.0/dist/maplibre-gl-layer-control.css" rel="stylesheet" />
+    <link href="https://unpkg.com/maplibre-gl-layer-control@0.14.1/dist/maplibre-gl-layer-control.css" rel="stylesheet" />
     <!-- maplibre-gl-components CSS -->
-    <link href="https://unpkg.com/maplibre-gl-components@0.14.0/dist/maplibre-gl-components.css" rel="stylesheet" />
+    <link href="https://unpkg.com/maplibre-gl-components@0.16.2/dist/maplibre-gl-components.css" rel="stylesheet" />
     <!-- Geoman for drawing -->
     <script src="https://cdn.jsdelivr.net/npm/@geoman-io/maplibre-geoman-free@0.6.1/dist/maplibre-geoman.umd.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/@geoman-io/maplibre-geoman-free@0.6.1/dist/maplibre-geoman.css" rel="stylesheet" />
@@ -40,11 +40,11 @@
         let LayerControl = null;
         let addControlGridFn = null;
 
-        const lcPromise = import('https://esm.sh/maplibre-gl-layer-control@0.13.0')
+        const lcPromise = import('https://esm.sh/maplibre-gl-layer-control@0.14.1')
             .then(mod => { LayerControl = mod.LayerControl; })
             .catch(() => console.warn('LayerControl library unavailable — layer control will be skipped'));
 
-        const cgPromise = import('https://esm.sh/maplibre-gl-components@0.14.0')
+        const cgPromise = import('https://esm.sh/maplibre-gl-components@0.16.2')
             .then(mod => { addControlGridFn = mod.addControlGrid; })
             .catch(() => console.warn('ControlGrid library unavailable — control grid will be skipped'));
 
@@ -338,7 +338,11 @@
                         exclude: config.exclude,
                         rows: config.rows,
                         columns: config.columns,
-                        collapsed: config.collapsed !== false
+                        collapsed: config.collapsed !== false,
+                        title: config.title,
+                        basemapStyleUrl: config.basemapStyleUrl,
+                        excludeLayers: config.excludeLayers,
+                        bookmarkOptions: config.bookmarkOptions
                     });
                     controlGridAdded = true;
                 } else {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "leaflet.heat": "^0.2.0",
     "mapbox-gl": "^3.18.1",
     "maplibre-gl": ">=5.14.0",
-    "maplibre-gl-components": "^0.16.1",
+    "maplibre-gl-components": "^0.16.2",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geophoto": "^0.2.0",
     "maplibre-gl-layer-control": "^0.14.1",

--- a/src/maplibre/MapLibreRenderer.ts
+++ b/src/maplibre/MapLibreRenderer.ts
@@ -3822,6 +3822,9 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     if (kwargs.excludeLayers !== undefined && kwargs.excludeLayers !== null) {
       options.excludeLayers = kwargs.excludeLayers;
     }
+    if (kwargs.bookmarkOptions !== undefined && kwargs.bookmarkOptions !== null) {
+      options.bookmarkOptions = kwargs.bookmarkOptions;
+    }
 
     this.controlGrid = addControlGrid(this.map, options as Parameters<typeof addControlGrid>[1]);
     this.controlsMap.set('control-grid', this.controlGrid as unknown as maplibregl.IControl);


### PR DESCRIPTION
## Summary
- Update maplibre-gl-layer-control CDN from 0.13.0 to 0.14.1 and maplibre-gl-components CDN from 0.14.0 to 0.16.2 in the HTML template
- Fix `bookmark_options` (and `title`, `basemapStyleUrl`, `excludeLayers`) not being persisted in the HTML export config, causing preloaded bookmarks to appear in notebooks but not in exported HTML
- Pass all control grid options through in the HTML template's `addControlGrid` call

## Test plan
- [ ] Create a map with `add_control_grid(bookmark_options={"bookmarks": [...]})` in a notebook
- [ ] Export to HTML and verify bookmarks appear in the exported file
- [ ] Verify CDN resources load correctly from the updated versions

Fix https://github.com/opengeos/anymap-ts/discussions/136

```python
from anymap_ts import Map

m = Map(center=[-122.4, 37.8], zoom=10)
m.add_control_grid(
    bookmark_options={
        "bookmarks": [
            {
                "id": "nyc",
                "name": "New York City",
                "lng": -74.006,
                "lat": 40.7128,
                "zoom": 12,
                "pitch": 0,
                "bearing": 0,
                "createdAt": 0,
            },
            {
                "id": "sf",
                "name": "San Francisco",
                "lng": -122.4194,
                "lat": 37.7749,
                "zoom": 12,
                "pitch": 0,
                "bearing": 0,
                "createdAt": 0,
            },
        ],
    },
)

m.to_html("map.html")
m
```