### PR TITLE
Add symbol layer type support for PMTiles

### DIFF
--- a/anymap_ts/mapbox.py
+++ b/anymap_ts/mapbox.py
@@ -747,7 +747,8 @@ class MapboxMap(MapWidget):
         discovers all source layers from the PMTiles metadata and renders each
         one with a distinct color. Geometry types from the metadata determine
         the layer type: Polygon becomes fill, LineString becomes line, and
-        Point becomes circle.
+        Point becomes circle. For text labels and icons, use the symbol layer
+        type with layout properties like text-field and icon-image.
 
         Args:
             url: URL to the PMTiles file.

--- a/anymap_ts/maplibre.py
+++ b/anymap_ts/maplibre.py
@@ -1196,8 +1196,10 @@ class MapLibreMap(MapWidget):
         discovers all source layers from the PMTiles metadata and renders each
         one with a distinct color. Geometry types from the metadata determine
         the layer type: Polygon becomes fill, LineString becomes line, and
-        Point becomes circle. This is similar to what https://pmtiles.io/
-        provides for visualizing PMTiles files.
+        Point becomes circle. For text labels and icons, use the symbol layer
+        type with layout properties like text-field and icon-image. This is
+        similar to what https://pmtiles.io/ provides for visualizing PMTiles
+        files.
 
         Args:
             url: URL to the PMTiles file (e.g., "https://example.com/data.pmtiles").

--- a/docs/maplibre/pmtiles_layer.ipynb
+++ b/docs/maplibre/pmtiles_layer.ipynb
@@ -166,7 +166,50 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 3: Raster PMTiles\n",
+    "## Example 3: Symbol Layer for Labels\n",
+    "\n",
+    "Use the `symbol` layer type to render text labels and icons from PMTiles.\n",
+    "Symbol layers support `text-field`, `text-size`, `text-color`, and other\n",
+    "MapLibre symbol properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add symbol layer for place labels\n",
+    "m3 = Map(\n",
+    "    center=[11.2558, 43.7696],  # Florence coordinates\n",
+    "    zoom=14,\n",
+    "    style=\"https://demotiles.maplibre.org/style.json\",\n",
+    "    height=\"500px\",\n",
+    ")\n",
+    "\n",
+    "m3.add_pmtiles_layer(\n",
+    "    url=\"https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles\",\n",
+    "    layer_id=\"place-labels\",\n",
+    "    style={\n",
+    "        \"type\": \"symbol\",\n",
+    "        \"source-layer\": \"places\",\n",
+    "        \"text-field\": [\"get\", \"name\"],\n",
+    "        \"text-size\": 14,\n",
+    "        \"text-color\": \"#1a1a2e\",\n",
+    "        \"text-halo-color\": \"#ffffff\",\n",
+    "        \"text-halo-width\": 2,\n",
+    "        \"text-allow-overlap\": False,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "m3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: Raster PMTiles\n",
     "\n",
     "PMTiles also supports raster tiles for satellite imagery, digital elevation models, etc."
    ]
@@ -180,7 +223,7 @@
     "# Note: This is a placeholder example as we don't have a public raster PMTiles URL\n",
     "# In practice, you would use your own raster PMTiles file\n",
     "\n",
-    "m3 = Map(\n",
+    "m4 = Map(\n",
     "    center=[-120.5, 35.5],\n",
     "    zoom=8,\n",
     "    style=\"https://demotiles.maplibre.org/style.json\",\n",
@@ -188,7 +231,7 @@
     ")\n",
     "\n",
     "# Example of how to add a raster PMTiles layer\n",
-    "# m3.add_pmtiles_layer(\n",
+    "# m4.add_pmtiles_layer(\n",
     "#     url=\"https://example.com/satellite.pmtiles\",\n",
     "#     layer_id=\"satellite\",\n",
     "#     source_type=\"raster\",\n",
@@ -198,7 +241,7 @@
     "print(\"For raster PMTiles, use source_type='raster' and adjust opacity as needed.\")\n",
     "print(\"The layer will be added as a raster layer with the specified opacity.\")\n",
     "\n",
-    "m3"
+    "m4"
    ]
   },
   {
@@ -269,6 +312,20 @@
     "    \"circle-color\": \"#00ff00\",\n",
     "    \"circle-radius\": 5,\n",
     "    \"circle-opacity\": 0.9\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "### For Symbol Layers (Text Labels and Icons)\n",
+    "```python\n",
+    "style = {\n",
+    "    \"type\": \"symbol\",\n",
+    "    \"source-layer\": \"layer_name\",\n",
+    "    \"text-field\": [\"get\", \"name\"],\n",
+    "    \"text-size\": 14,\n",
+    "    \"text-color\": \"#333333\",\n",
+    "    \"text-halo-color\": \"#ffffff\",\n",
+    "    \"text-halo-width\": 1,\n",
+    "    \"text-allow-overlap\": False\n",
     "}\n",
     "```\n",
     "\n",

--- a/src/mapbox/MapboxRenderer.ts
+++ b/src/mapbox/MapboxRenderer.ts
@@ -2338,7 +2338,7 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
   /**
    * Map geometry type string to Mapbox layer type.
    */
-  private geometryToLayerType(geometryType: string): 'fill' | 'line' | 'circle' {
+  private geometryToLayerType(geometryType: string): 'fill' | 'line' | 'circle' | 'symbol' {
     const lower = geometryType.toLowerCase();
     if (lower.includes('polygon')) return 'fill';
     if (lower.includes('line')) return 'line';
@@ -2349,7 +2349,7 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
   /**
    * Infer layer type from a source layer name when geometry_type is missing.
    */
-  private inferLayerTypeFromName(layerName: string): 'fill' | 'line' | 'circle' {
+  private inferLayerTypeFromName(layerName: string): 'fill' | 'line' | 'circle' | 'symbol' {
     const lower = layerName.toLowerCase();
     const linePatterns = [
       'road', 'street', 'highway', 'path', 'route', 'rail',
@@ -2398,14 +2398,38 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
         const prefix = (kwargs.prefix as string) ?? '';
         await this.autoDiscoverPMTilesLayers(url, layerId, sourceId, opacity, visible, fitBounds, prefix, popupConfig);
       } else if (!this.map.getLayer(layerId)) {
+        const layerType = sourceType === 'vector' ? ((style.type as string) || 'fill') : 'raster';
+        const { paint: extractedPaint, layout: extractedLayout } = this.extractPaintAndLayoutFromStyle(style, layerType);
+
+        const defaultLayout: Record<string, unknown> = {
+          visibility: visible ? 'visible' : 'none',
+        };
+        if (layerType === 'symbol') {
+          if (!extractedLayout['text-field'] && !extractedLayout['icon-image']) {
+            defaultLayout['text-field'] = ['get', 'name'];
+          }
+          if (!extractedLayout['text-size']) {
+            defaultLayout['text-size'] = 12;
+          }
+        }
+
+        let defaultPaint: Record<string, unknown> = {};
+        if (sourceType === 'vector') {
+          if (layerType === 'symbol') {
+            defaultPaint = { 'text-color': '#3388ff', 'text-opacity': opacity, 'text-halo-color': '#ffffff', 'text-halo-width': 1 };
+          } else {
+            defaultPaint = { 'fill-color': '#3388ff', 'fill-opacity': opacity };
+          }
+        } else {
+          defaultPaint = { 'raster-opacity': opacity };
+        }
+
         const layerConfig: Record<string, unknown> = {
           id: layerId,
-          type: sourceType === 'vector' ? ((style.type as string) || 'fill') : 'raster',
+          type: layerType,
           source: sourceId,
-          layout: { visibility: visible ? 'visible' : 'none' },
-          paint: sourceType === 'vector'
-            ? { 'fill-color': '#3388ff', 'fill-opacity': opacity, ...this.extractPaintFromStyle(style) }
-            : { 'raster-opacity': opacity },
+          layout: { ...defaultLayout, ...extractedLayout },
+          paint: { ...defaultPaint, ...extractedPaint },
         };
         if (style['source-layer']) {
           layerConfig['source-layer'] = style['source-layer'];
@@ -2445,11 +2469,39 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
     return paint;
   }
 
+  private extractPaintAndLayoutFromStyle(
+    style: Record<string, unknown>,
+    layerType: string,
+  ): { paint: Record<string, unknown>; layout: Record<string, unknown> } {
+    const paint: Record<string, unknown> = {};
+    const layout: Record<string, unknown> = {};
+    const layoutKeys = [
+      'text-field', 'text-size', 'text-font', 'text-anchor',
+      'text-offset', 'text-rotate', 'text-max-width',
+      'text-allow-overlap', 'text-ignore-placement',
+      'text-justify', 'text-letter-spacing', 'text-line-height',
+      'text-transform', 'text-padding',
+      'icon-image', 'icon-size', 'icon-anchor', 'icon-offset',
+      'icon-rotate', 'icon-allow-overlap', 'icon-ignore-placement',
+      'icon-padding', 'symbol-placement', 'symbol-spacing',
+      'symbol-sort-key',
+    ];
+    for (const [key, value] of Object.entries(style)) {
+      if (key === 'type' || key === 'source-layer') continue;
+      if (layerType === 'symbol' && layoutKeys.includes(key)) {
+        layout[key] = value;
+      } else {
+        paint[key] = value;
+      }
+    }
+    return { paint, layout };
+  }
+
   /**
    * Build paint properties for a given layer type.
    */
   private buildPMTilesPaint(
-    layerType: 'fill' | 'line' | 'circle',
+    layerType: 'fill' | 'line' | 'circle' | 'symbol',
     color: string,
     opacity: number,
   ): Record<string, unknown> {
@@ -2457,11 +2509,38 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
       return { 'fill-color': color, 'fill-opacity': opacity * 0.6, 'fill-outline-color': color };
     } else if (layerType === 'line') {
       return { 'line-color': color, 'line-width': 2, 'line-opacity': opacity };
+    } else if (layerType === 'symbol') {
+      return { 'text-color': color, 'text-opacity': opacity, 'text-halo-color': '#ffffff', 'text-halo-width': 1 };
     }
     return {
       'circle-color': color, 'circle-radius': 2, 'circle-opacity': opacity,
       'circle-stroke-color': color, 'circle-stroke-width': 0.5,
     };
+  }
+
+  /**
+   * Build layout properties for symbol layers.
+   */
+  private buildPMTilesSymbolLayout(
+    sourceLayerFields: string[],
+    visible: boolean,
+  ): Record<string, unknown> {
+    const layout: Record<string, unknown> = {
+      visibility: visible ? 'visible' : 'none',
+      'text-size': 12,
+      'text-anchor': 'center',
+      'text-allow-overlap': false,
+    };
+    const textFieldCandidates = ['name', 'label', 'text', 'title', 'description'];
+    let textField = 'name';
+    for (const candidate of textFieldCandidates) {
+      if (sourceLayerFields.some(f => f.toLowerCase() === candidate)) {
+        textField = sourceLayerFields.find(f => f.toLowerCase() === candidate)!;
+        break;
+      }
+    }
+    layout['text-field'] = ['get', textField];
+    return layout;
   }
 
   /**
@@ -2509,8 +2588,8 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
         : this.inferLayerTypeFromName(vl.id),
     }));
 
-    // Sort so fill renders first, then line, then circle (points on top)
-    const renderOrder: Record<string, number> = { fill: 0, line: 1, circle: 2 };
+    // Sort so fill renders first, then line, then circle, then symbol (labels on top)
+    const renderOrder: Record<string, number> = { fill: 0, line: 1, circle: 2, symbol: 3 };
     layerEntries.sort((a, b) => (renderOrder[a.mlType] ?? 0) - (renderOrder[b.mlType] ?? 0));
 
     const subLayerIds: string[] = [];
@@ -2518,13 +2597,19 @@ export class MapboxRenderer extends BaseMapRenderer<MapboxMap> {
     for (const { vl, color, mlType } of layerEntries) {
       const subLayerId = prefix ? `${prefix}-${vl.id}` : vl.id;
 
+      // For symbol layers, extract field names from metadata to pick a text-field
+      const vlFields = (vl as Record<string, unknown>).fields as Record<string, string> | undefined;
+      const fieldNames = vlFields ? Object.keys(vlFields) : [];
+
       if (!this.map.getLayer(subLayerId)) {
         this.map.addLayer({
           id: subLayerId,
           type: mlType,
           source: sourceId,
           'source-layer': vl.id,
-          layout: { visibility: visible ? 'visible' : 'none' },
+          layout: mlType === 'symbol'
+            ? this.buildPMTilesSymbolLayout(fieldNames, visible)
+            : { visibility: visible ? 'visible' : 'none' },
           paint: this.buildPMTilesPaint(mlType, color, opacity),
         } as mapboxgl.AnyLayer);
         subLayerIds.push(subLayerId);

--- a/src/maplibre/MapLibreRenderer.ts
+++ b/src/maplibre/MapLibreRenderer.ts
@@ -3901,7 +3901,7 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
   /**
    * Map geometry type string to MapLibre layer type.
    */
-  private geometryToLayerType(geometryType: string): 'fill' | 'line' | 'circle' {
+  private geometryToLayerType(geometryType: string): 'fill' | 'line' | 'circle' | 'symbol' {
     const lower = geometryType.toLowerCase();
     if (lower.includes('polygon')) return 'fill';
     if (lower.includes('line')) return 'line';
@@ -3913,7 +3913,7 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
    * Infer MapLibre layer type from a source layer name when geometry_type
    * is not available in the PMTiles metadata.
    */
-  private inferLayerTypeFromName(layerName: string): 'fill' | 'line' | 'circle' {
+  private inferLayerTypeFromName(layerName: string): 'fill' | 'line' | 'circle' | 'symbol' {
     const lower = layerName.toLowerCase();
     // Names that typically represent line geometries
     const linePatterns = [
@@ -4000,13 +4000,48 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
               'circle-radius': 5,
               'circle-opacity': opacity,
             };
+          } else if (layerType === 'symbol') {
+            defaultPaint = {
+              'text-color': '#3388ff',
+              'text-opacity': opacity,
+              'text-halo-color': '#ffffff',
+              'text-halo-width': 1,
+            };
           }
 
-          // Extract paint properties from style (everything except type and source-layer)
+          // Extract paint and layout properties from style
           const paintFromStyle: Record<string, unknown> = {};
+          const layoutFromStyle: Record<string, unknown> = {};
+          const layoutKeys = [
+            'text-field', 'text-size', 'text-font', 'text-anchor',
+            'text-offset', 'text-rotate', 'text-max-width',
+            'text-allow-overlap', 'text-ignore-placement',
+            'text-justify', 'text-letter-spacing', 'text-line-height',
+            'text-transform', 'text-padding',
+            'icon-image', 'icon-size', 'icon-anchor', 'icon-offset',
+            'icon-rotate', 'icon-allow-overlap', 'icon-ignore-placement',
+            'icon-padding', 'symbol-placement', 'symbol-spacing',
+            'symbol-sort-key',
+          ];
           for (const [key, value] of Object.entries(style)) {
-            if (key !== 'type' && key !== 'source-layer') {
+            if (key === 'type' || key === 'source-layer') continue;
+            if (layoutKeys.includes(key)) {
+              layoutFromStyle[key] = value;
+            } else {
               paintFromStyle[key] = value;
+            }
+          }
+
+          // Build layout: default visibility + symbol-specific defaults + user overrides
+          const defaultLayout: Record<string, unknown> = {
+            visibility: visible ? 'visible' : 'none',
+          };
+          if (layerType === 'symbol') {
+            if (!layoutFromStyle['text-field'] && !layoutFromStyle['icon-image']) {
+              defaultLayout['text-field'] = ['get', 'name'];
+            }
+            if (!layoutFromStyle['text-size']) {
+              defaultLayout['text-size'] = 12;
             }
           }
 
@@ -4014,9 +4049,7 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
             id: layerId,
             type: layerType,
             source: sourceId,
-            layout: {
-              visibility: visible ? 'visible' : 'none',
-            },
+            layout: { ...defaultLayout, ...layoutFromStyle },
             paint: { ...defaultPaint, ...paintFromStyle },
           };
 
@@ -4075,7 +4108,7 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
    * Build paint properties for a given MapLibre layer type.
    */
   private buildPMTilesPaint(
-    layerType: 'fill' | 'line' | 'circle',
+    layerType: 'fill' | 'line' | 'circle' | 'symbol',
     color: string,
     opacity: number,
   ): Record<string, unknown> {
@@ -4083,11 +4116,40 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       return { 'fill-color': color, 'fill-opacity': opacity * 0.6, 'fill-outline-color': color };
     } else if (layerType === 'line') {
       return { 'line-color': color, 'line-width': 2, 'line-opacity': opacity };
+    } else if (layerType === 'symbol') {
+      return { 'text-color': color, 'text-opacity': opacity, 'text-halo-color': '#ffffff', 'text-halo-width': 1 };
     }
     return {
       'circle-color': color, 'circle-radius': 3, 'circle-opacity': opacity,
       'circle-stroke-color': color, 'circle-stroke-width': 1,
     };
+  }
+
+  /**
+   * Build layout properties for symbol layers. Symbol layers require layout
+   * properties (text-field, icon-image, etc.) to render.
+   */
+  private buildPMTilesSymbolLayout(
+    sourceLayerFields: string[],
+    visible: boolean,
+  ): Record<string, unknown> {
+    const layout: Record<string, unknown> = {
+      visibility: visible ? 'visible' : 'none',
+      'text-size': 12,
+      'text-anchor': 'center',
+      'text-allow-overlap': false,
+    };
+    // Use the first text-like field name as the label, or fallback to 'name'
+    const textFieldCandidates = ['name', 'label', 'text', 'title', 'description'];
+    let textField = 'name';
+    for (const candidate of textFieldCandidates) {
+      if (sourceLayerFields.some(f => f.toLowerCase() === candidate)) {
+        textField = sourceLayerFields.find(f => f.toLowerCase() === candidate)!;
+        break;
+      }
+    }
+    layout['text-field'] = ['get', textField];
+    return layout;
   }
 
   /**
@@ -4137,8 +4199,8 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
         : this.inferLayerTypeFromName(vl.id),
     }));
 
-    // Sort so fill renders first, then line, then circle (points on top)
-    const renderOrder: Record<string, number> = { fill: 0, line: 1, circle: 2 };
+    // Sort so fill renders first, then line, then circle, then symbol (labels on top)
+    const renderOrder: Record<string, number> = { fill: 0, line: 1, circle: 2, symbol: 3 };
     layerEntries.sort((a, b) => (renderOrder[a.mlType] ?? 0) - (renderOrder[b.mlType] ?? 0));
 
     const subLayerIds: string[] = [];
@@ -4147,12 +4209,18 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       const idBase = prefix ? `${prefix}-${vl.id}` : vl.id;
       const subLayerId = idBase;
 
+      // For symbol layers, extract field names from metadata to pick a text-field
+      const vlFields = (vl as Record<string, unknown>).fields as Record<string, string> | undefined;
+      const fieldNames = vlFields ? Object.keys(vlFields) : [];
+
       const layerConfig: Record<string, unknown> = {
         id: subLayerId,
         type: mlType,
         source: sourceId,
         'source-layer': vl.id,
-        layout: { visibility: visible ? 'visible' : 'none' },
+        layout: mlType === 'symbol'
+          ? this.buildPMTilesSymbolLayout(fieldNames, visible)
+          : { visibility: visible ? 'visible' : 'none' },
         paint: this.buildPMTilesPaint(mlType, color, opacity),
       };
 


### PR DESCRIPTION
## Summary

Closes #146

- Adds `symbol` layer type support for PMTiles in both MapLibre and Mapbox renderers, enabling text labels and icons from vector tiles
- Symbol layers properly separate layout properties (`text-field`, `text-size`, `icon-image`, etc.) from paint properties (`text-color`, `text-halo-color`, etc.) per the MapLibre/Mapbox GL spec
- Auto-discovery mode now renders symbol layers on top of other layer types and auto-detects a `text-field` from metadata field names (preferring `name`, `label`, `text`, `title`)
- Adds symbol layer example to the PMTiles notebook documentation

## Test plan

- [ ] Verify symbol layer renders text labels from a PMTiles file with `type: "symbol"` and `text-field` in the style dict
- [ ] Verify auto-discovery mode still works correctly with existing PMTiles (fill, line, circle layers unaffected)
- [ ] Verify symbol layout properties (`text-field`, `text-size`, `text-allow-overlap`, etc.) are correctly routed to `layout` instead of `paint`
- [ ] Test with both MapLibre and Mapbox backends

```python
from anymap_ts import Map

# Add symbol layer for place labels
m3 = Map(
    center=[11.2558, 43.7696],  # Florence coordinates
    zoom=14,
    style="https://demotiles.maplibre.org/style.json",
    height="500px",
)

m3.add_pmtiles_layer(
    url="https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles",
    layer_id="place-labels",
    style={
        "type": "symbol",
        "source-layer": "places",
        "text-field": ["get", "name"],
        "text-size": 14,
        "text-color": "#1a1a2e",
        "text-halo-color": "#ffffff",
        "text-halo-width": 2,
        "text-allow-overlap": False,
    },
)

m3
```
<img width="948" height="493" alt="image" src="https://github.com/user-attachments/assets/eef033f5-a546-4d98-a63b-21e6d6914778" />
