### PR TITLE
Fix deck.gl layers in HTML export and add layer control to DeckGLMap

### DIFF
--- a/anymap_ts/templates/deckgl.html
+++ b/anymap_ts/templates/deckgl.html
@@ -9,6 +9,10 @@
     <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
     <!-- deck.gl -->
     <script src="https://unpkg.com/deck.gl@9/dist.min.js"></script>
+    <!-- maplibre-gl-layer-control CSS -->
+    <link href="https://unpkg.com/maplibre-gl-layer-control@0.14.1/dist/maplibre-gl-layer-control.css" rel="stylesheet" />
+    <!-- maplibre-gl-components CSS -->
+    <link href="https://unpkg.com/maplibre-gl-components@0.16.2/dist/maplibre-gl-components.css" rel="stylesheet" />
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         html, body { height: 100%; }
@@ -17,9 +21,30 @@
 </head>
 <body>
     <div id="map"></div>
-    <script>
+    <script type="module">
         // Map state from Python
         const state = {{state}};
+
+        // Track added layers for layer control
+        const addedLayers = [];
+        let layerControlConfig = null;
+        let controlGridConfig = null;
+        let controlGridAdded = false;
+        let layerControlAdded = false;
+        let layerControlInstance = null;
+        let layerControlOrderSyncTimer = null;
+
+        // Load optional dependencies in parallel (non-blocking)
+        let LayerControl = null;
+        let addControlGridFn = null;
+
+        const lcPromise = import('https://esm.sh/maplibre-gl-layer-control@0.14.1')
+            .then(mod => { LayerControl = mod.LayerControl; })
+            .catch(() => console.warn('LayerControl library unavailable'));
+
+        const cgPromise = import('https://esm.sh/maplibre-gl-components@0.16.2')
+            .then(mod => { addControlGridFn = mod.addControlGrid; })
+            .catch(() => console.warn('ControlGrid library unavailable'));
 
         // Create MapLibre map
         const map = new maplibregl.Map({
@@ -37,7 +62,59 @@
 
         const DECK_SENTINEL_ID = '__deck-overlay-anchor';
 
-        map.on('load', function() {
+        // Deck layer adapter for layer control
+        function setDeckVisibility(layerId, visible) {
+            const layer = deckLayers.get(layerId);
+            if (!layer) return;
+            deckLayers.set(layerId, layer.clone({ visible }));
+            updateDeckOverlay();
+        }
+
+        function setDeckOpacity(layerId, opacity) {
+            const layer = deckLayers.get(layerId);
+            if (!layer) return;
+            deckLayers.set(layerId, layer.clone({ opacity }));
+            updateDeckOverlay();
+        }
+
+        const deckChangeCallbacks = [];
+
+        const deckLayerAdapter = {
+            type: 'deck',
+            getLayerIds() {
+                return Array.from(deckLayers.keys());
+            },
+            getLayerState(layerId) {
+                const layer = deckLayers.get(layerId);
+                if (!layer || !layer.props) return null;
+                return {
+                    visible: layer.props.visible !== false,
+                    opacity: layer.props.opacity ?? 1,
+                    name: layerId,
+                };
+            },
+            setVisibility(layerId, visible) {
+                setDeckVisibility(layerId, visible);
+            },
+            setOpacity(layerId, opacity) {
+                setDeckOpacity(layerId, opacity);
+            },
+            getName(layerId) {
+                return layerId;
+            },
+            getSymbolType() {
+                return 'deck';
+            },
+            onLayerChange(callback) {
+                deckChangeCallbacks.push(callback);
+                return () => {
+                    const idx = deckChangeCallbacks.indexOf(callback);
+                    if (idx >= 0) deckChangeCallbacks.splice(idx, 1);
+                };
+            },
+        };
+
+        map.on('load', async function() {
             // Initialize deck.gl overlay
             deckOverlay = new deck.MapboxOverlay({
                 interleaved: true,
@@ -61,12 +138,44 @@
                 });
             }
 
-            // Replay JS calls
+            // 1. Replay JS calls
             for (const call of state.js_calls || []) {
                 try {
                     executeMethod(call.method, call.args, call.kwargs);
                 } catch (e) {
                     console.error('Error executing', call.method, e);
+                }
+            }
+
+            // 2. Wait for optional imports to settle
+            await Promise.allSettled([lcPromise, cgPromise]);
+
+            // 3. Add layer control if configured
+            if (!layerControlAdded && (layerControlConfig || (state.controls && state.controls['layer-control']))) {
+                const config = layerControlConfig || state.controls['layer-control'];
+                if (LayerControl) {
+                    createLayerControl(config);
+                    layerControlAdded = true;
+                }
+            }
+
+            // 4. Add control grid if configured
+            if (!controlGridAdded && (controlGridConfig || (state.controls && state.controls['control-grid']))) {
+                const config = controlGridConfig || state.controls['control-grid'];
+                if (addControlGridFn) {
+                    addControlGridFn(map, {
+                        position: config.position || 'top-right',
+                        defaultControls: config.defaultControls,
+                        exclude: config.exclude,
+                        rows: config.rows,
+                        columns: config.columns,
+                        collapsed: config.collapsed !== false,
+                        title: config.title,
+                        basemapStyleUrl: config.basemapStyleUrl,
+                        excludeLayers: config.excludeLayers,
+                        bookmarkOptions: config.bookmarkOptions
+                    });
+                    controlGridAdded = true;
                 }
             }
         });
@@ -83,6 +192,15 @@
             }
             const layers = Array.from(deckLayers.values());
             deckOverlay.setProps({ layers });
+            map.triggerRepaint();
+            scheduleLayerControlOrderSync();
+        }
+
+        function makeAccessor(value, defaultProp, fallbackFn) {
+            if (typeof value === 'string') return d => d[value];
+            if (typeof value === 'function') return value;
+            if (value !== undefined && value !== null) return value;
+            return fallbackFn || (d => d[defaultProp]);
         }
 
         function executeMethod(method, args, kwargs) {
@@ -92,6 +210,7 @@
                     const url = args[0];
                     const name = kwargs.name || 'basemap';
                     const sourceId = 'basemap-' + name;
+                    const layerId = name;
                     if (!map.getSource(sourceId)) {
                         map.addSource(sourceId, {
                             type: 'raster',
@@ -100,12 +219,24 @@
                             attribution: kwargs.attribution || ''
                         });
                     }
-                    if (!map.getLayer(sourceId)) {
+                    if (!map.getLayer(layerId)) {
+                        // Insert basemap below deck sentinel so deck layers render on top
+                        let effectiveBeforeId;
+                        if (map.getLayer(DECK_SENTINEL_ID)) {
+                            const styleLayers = map.getStyle()?.layers || [];
+                            const si = styleLayers.findIndex(l => l.id === DECK_SENTINEL_ID);
+                            let ii = si;
+                            for (let i = si - 1; i >= 0; i--) {
+                                if (styleLayers[i].id.startsWith('@@deck.gl')) { ii = i; } else { break; }
+                            }
+                            effectiveBeforeId = styleLayers[ii]?.id;
+                        }
                         map.addLayer({
-                            id: sourceId,
+                            id: layerId,
                             type: 'raster',
                             source: sourceId
-                        });
+                        }, effectiveBeforeId);
+                        addedLayers.push({ id: layerId, type: 'raster' });
                     }
                     break;
                 }
@@ -119,13 +250,15 @@
                             data: kwargs.data
                         });
                     }
+                    const geoLayerType = kwargs.layerType || 'circle';
                     if (!map.getLayer(layerName)) {
                         map.addLayer({
                             id: layerName,
-                            type: kwargs.layerType || 'circle',
+                            type: geoLayerType,
                             source: sourceIdGeo,
                             paint: kwargs.paint || {}
                         });
+                        addedLayers.push({ id: layerName, type: geoLayerType });
                     }
                     if (kwargs.fitBounds && kwargs.bounds) {
                         map.fitBounds([
@@ -154,6 +287,7 @@
                             type: 'raster',
                             source: tileSourceId
                         });
+                        addedLayers.push({ id: tileName, type: 'raster' });
                     }
                     break;
                 }
@@ -214,10 +348,10 @@
                         radiusMinPixels: kwargs.radiusMinPixels ?? 1,
                         radiusMaxPixels: kwargs.radiusMaxPixels ?? 100,
                         lineWidthMinPixels: kwargs.lineWidthMinPixels ?? 1,
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
-                        getRadius: kwargs.getRadius ?? kwargs.radius ?? 5,
-                        getFillColor: kwargs.getFillColor ?? kwargs.fillColor ?? [51, 136, 255, 200],
-                        getLineColor: kwargs.getLineColor ?? kwargs.lineColor ?? [255, 255, 255, 255]
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getRadius: makeAccessor(kwargs.getRadius ?? kwargs.radius, 'radius', () => 5),
+                        getFillColor: makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 200]),
+                        getLineColor: makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [255, 255, 255, 255])
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -231,11 +365,11 @@
                         data: kwargs.data,
                         pickable: kwargs.pickable !== false,
                         opacity: kwargs.opacity ?? 0.8,
-                        getWidth: kwargs.getWidth ?? kwargs.width ?? 1,
-                        getSourcePosition: d => d.source || d.from || d.sourcePosition,
-                        getTargetPosition: d => d.target || d.to || d.targetPosition,
-                        getSourceColor: kwargs.getSourceColor ?? kwargs.sourceColor ?? [51, 136, 255, 255],
-                        getTargetColor: kwargs.getTargetColor ?? kwargs.targetColor ?? [255, 136, 51, 255]
+                        getWidth: makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
+                        getSourcePosition: makeAccessor(kwargs.getSourcePosition, 'source', d => d.source || d.from || d.sourcePosition),
+                        getTargetPosition: makeAccessor(kwargs.getTargetPosition, 'target', d => d.target || d.to || d.targetPosition),
+                        getSourceColor: makeAccessor(kwargs.getSourceColor ?? kwargs.sourceColor, 'sourceColor', () => [51, 136, 255, 255]),
+                        getTargetColor: makeAccessor(kwargs.getTargetColor ?? kwargs.targetColor, 'targetColor', () => [255, 136, 51, 255])
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -251,9 +385,9 @@
                         opacity: kwargs.opacity ?? 0.8,
                         widthScale: kwargs.widthScale ?? 1,
                         widthMinPixels: kwargs.widthMinPixels ?? 1,
-                        getPath: d => d.path || d.coordinates,
-                        getColor: kwargs.getColor ?? kwargs.color ?? [51, 136, 255, 200],
-                        getWidth: kwargs.getWidth ?? kwargs.width ?? 1
+                        getPath: makeAccessor(kwargs.getPath, 'path', d => d.path || d.coordinates),
+                        getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [51, 136, 255, 200]),
+                        getWidth: makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1)
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -272,11 +406,11 @@
                         extruded: kwargs.extruded ?? false,
                         wireframe: kwargs.wireframe ?? false,
                         lineWidthMinPixels: kwargs.lineWidthMinPixels ?? 1,
-                        getPolygon: d => d.polygon || d.contour || d.coordinates,
-                        getElevation: kwargs.getElevation ?? kwargs.elevation ?? 0,
-                        getFillColor: kwargs.getFillColor ?? kwargs.fillColor ?? [51, 136, 255, 128],
-                        getLineColor: kwargs.getLineColor ?? kwargs.lineColor ?? [0, 0, 255, 255],
-                        getLineWidth: kwargs.getLineWidth ?? kwargs.lineWidth ?? 1
+                        getPolygon: makeAccessor(kwargs.getPolygon, 'polygon', d => d.polygon || d.contour || d.coordinates),
+                        getElevation: makeAccessor(kwargs.getElevation ?? kwargs.elevation, 'elevation', () => 0),
+                        getFillColor: makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 128]),
+                        getLineColor: makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [0, 0, 255, 255]),
+                        getLineWidth: makeAccessor(kwargs.getLineWidth ?? kwargs.lineWidth, 'lineWidth', () => 1)
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -293,7 +427,7 @@
                         extruded: kwargs.extruded ?? true,
                         radius: kwargs.radius ?? 1000,
                         elevationScale: kwargs.elevationScale ?? 4,
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
                         colorRange: kwargs.colorRange ?? [
                             [1, 152, 189],
                             [73, 227, 206],
@@ -318,8 +452,8 @@
                         radiusPixels: kwargs.radiusPixels ?? 30,
                         intensity: kwargs.intensity ?? 1,
                         threshold: kwargs.threshold ?? 0.05,
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
-                        getWeight: kwargs.getWeight ?? kwargs.weight ?? 1,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getWeight: makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
                         colorRange: kwargs.colorRange ?? [
                             [255, 255, 178, 25],
                             [254, 217, 118, 85],
@@ -344,7 +478,7 @@
                         extruded: kwargs.extruded ?? true,
                         cellSize: kwargs.cellSize ?? 200,
                         elevationScale: kwargs.elevationScale ?? 4,
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
                         colorRange: kwargs.colorRange ?? [
                             [1, 152, 189],
                             [73, 227, 206],
@@ -368,10 +502,10 @@
                         opacity: kwargs.opacity ?? 1,
                         iconAtlas: kwargs.iconAtlas,
                         iconMapping: kwargs.iconMapping,
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
-                        getIcon: d => d.icon || 'marker',
-                        getSize: kwargs.getSize ?? kwargs.size ?? 20,
-                        getColor: kwargs.getColor ?? kwargs.color ?? [255, 255, 255, 255]
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getIcon: makeAccessor(kwargs.getIcon, 'icon', d => d.icon || 'marker'),
+                        getSize: makeAccessor(kwargs.getSize ?? kwargs.size, 'size', () => 20),
+                        getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [255, 255, 255, 255])
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -385,11 +519,11 @@
                         data: kwargs.data,
                         pickable: kwargs.pickable !== false,
                         opacity: kwargs.opacity ?? 1,
-                        getPosition: kwargs.getPosition ?? (d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-                        getText: kwargs.getText ?? (d => d.text || d.label || d.name || ''),
-                        getSize: kwargs.getSize ?? kwargs.size ?? 12,
-                        getColor: kwargs.getColor ?? kwargs.color ?? [0, 0, 0, 255],
-                        getAngle: kwargs.getAngle ?? 0,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getText: makeAccessor(kwargs.getText, 'text', d => d.text || d.label || d.name || ''),
+                        getSize: makeAccessor(kwargs.getSize ?? kwargs.size, 'size', () => 12),
+                        getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [0, 0, 0, 255]),
+                        getAngle: makeAccessor(kwargs.getAngle, 'angle', () => 0),
                         getTextAnchor: kwargs.getTextAnchor ?? 'middle',
                         getAlignmentBaseline: kwargs.getAlignmentBaseline ?? 'center'
                     });
@@ -411,11 +545,11 @@
                         wireframe: kwargs.wireframe ?? false,
                         lineWidthMinPixels: kwargs.lineWidthMinPixels ?? 1,
                         pointRadiusMinPixels: kwargs.pointRadiusMinPixels ?? 2,
-                        getFillColor: kwargs.getFillColor ?? kwargs.fillColor ?? [51, 136, 255, 128],
-                        getLineColor: kwargs.getLineColor ?? kwargs.lineColor ?? [0, 0, 0, 255],
-                        getLineWidth: kwargs.getLineWidth ?? kwargs.lineWidth ?? 1,
-                        getPointRadius: kwargs.getPointRadius ?? kwargs.pointRadius ?? 5,
-                        getElevation: kwargs.getElevation ?? kwargs.elevation ?? 0
+                        getFillColor: makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 128]),
+                        getLineColor: makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [0, 0, 0, 255]),
+                        getLineWidth: makeAccessor(kwargs.getLineWidth ?? kwargs.lineWidth, 'lineWidth', () => 1),
+                        getPointRadius: makeAccessor(kwargs.getPointRadius ?? kwargs.pointRadius, 'pointRadius', () => 5),
+                        getElevation: makeAccessor(kwargs.getElevation ?? kwargs.elevation, 'elevation', () => 0)
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -435,8 +569,8 @@
                             { threshold: 5, color: [51, 136, 255], strokeWidth: 2 },
                             { threshold: 10, color: [0, 0, 255], strokeWidth: 3 }
                         ],
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
-                        getWeight: kwargs.getWeight ?? kwargs.weight ?? 1
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getWeight: makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1)
                     });
                     deckLayers.set(id, layer);
                     updateDeckOverlay();
@@ -451,8 +585,8 @@
                         pickable: kwargs.pickable !== false,
                         opacity: kwargs.opacity ?? 0.8,
                         cellSizePixels: kwargs.cellSizePixels ?? 50,
-                        getPosition: d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
-                        getWeight: kwargs.getWeight ?? kwargs.weight ?? 1,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getWeight: makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
                         colorRange: kwargs.colorRange ?? [
                             [255, 255, 178, 25],
                             [254, 217, 118, 85],
@@ -474,6 +608,16 @@
                     break;
                 }
 
+                case 'addLayerControl': {
+                    layerControlConfig = kwargs;
+                    break;
+                }
+
+                case 'addControlGrid': {
+                    controlGridConfig = kwargs;
+                    break;
+                }
+
                 case 'setDeckLayerVisibility': {
                     const [id, visible] = args;
                     const layer = deckLayers.get(id);
@@ -488,6 +632,105 @@
                 default:
                     console.log('Unknown method:', method);
             }
+        }
+        function getLayerControlOrder() {
+            const styleLayers = map.getStyle()?.layers || [];
+            const deckLayerIds = Array.from(deckLayers.keys());
+            if (styleLayers.length === 0) return deckLayerIds;
+
+            const orderedLayerIds = [];
+            let insertedDeckLayers = false;
+
+            for (const layer of styleLayers) {
+                if (layer.id === DECK_SENTINEL_ID) {
+                    if (!insertedDeckLayers) {
+                        orderedLayerIds.push(...deckLayerIds);
+                        insertedDeckLayers = true;
+                    }
+                    continue;
+                }
+                orderedLayerIds.push(layer.id);
+            }
+
+            if (!insertedDeckLayers) {
+                orderedLayerIds.push(...deckLayerIds);
+            }
+
+            return orderedLayerIds;
+        }
+
+        function syncLayerControlOrder() {
+            if (!layerControlInstance) return;
+
+            const layerStates = layerControlInstance.state && layerControlInstance.state.layerStates;
+            if (!layerStates || typeof layerControlInstance.buildLayerItems !== 'function') return;
+
+            const desiredOrder = getLayerControlOrder();
+            if (desiredOrder.length === 0) return;
+
+            const currentOrder = Object.keys(layerStates);
+            const hasBackground = currentOrder.includes('Background');
+            const currentLayerIds = currentOrder.filter(id => id !== 'Background');
+            const currentSet = new Set(currentLayerIds);
+            const desiredSet = new Set(desiredOrder);
+            const reorderedIds = [
+                ...desiredOrder.filter(id => currentSet.has(id)),
+                ...currentLayerIds.filter(id => !desiredSet.has(id)),
+            ];
+
+            if (reorderedIds.length === 0) return;
+
+            const isSameOrder = reorderedIds.length === currentLayerIds.length
+                && reorderedIds.every((id, index) => id === currentLayerIds[index]);
+            if (isSameOrder) return;
+
+            const reorderedStates = {};
+            if (hasBackground && Object.prototype.hasOwnProperty.call(layerStates, 'Background')) {
+                reorderedStates.Background = layerStates.Background;
+            }
+            reorderedIds.forEach(id => { reorderedStates[id] = layerStates[id]; });
+
+            layerControlInstance.state.layerStates = reorderedStates;
+            layerControlInstance.targetLayers = hasBackground
+                ? ['Background', ...reorderedIds]
+                : [...reorderedIds];
+            layerControlInstance.buildLayerItems();
+        }
+
+        function scheduleLayerControlOrderSync() {
+            if (!layerControlInstance) return;
+            if (layerControlOrderSyncTimer !== null) {
+                window.clearTimeout(layerControlOrderSyncTimer);
+            }
+            layerControlOrderSyncTimer = window.setTimeout(() => {
+                syncLayerControlOrder();
+                layerControlOrderSyncTimer = null;
+            }, 150);
+        }
+
+        function handleLayerControlReorder(layerOrder) {
+            if (deckLayers.size === 0) return;
+            updateDeckOverlay();
+        }
+
+        function createLayerControl(config) {
+            const position = config.position || 'top-right';
+            const collapsed = config.collapsed !== false;
+
+            const layerIds = addedLayers.map(layer => layer.id);
+
+            const customAdapters = [];
+            if (deckLayers.size > 0) customAdapters.push(deckLayerAdapter);
+
+            layerControlInstance = new LayerControl({
+                collapsed: collapsed,
+                layers: layerIds,
+                customLayerAdapters: customAdapters.length > 0 ? customAdapters : undefined,
+                onLayerReorder: handleLayerControlReorder,
+            });
+            map.addControl(layerControlInstance, position);
+            syncLayerControlOrder();
+            scheduleLayerControlOrderSync();
         }
     </script>
 </body>

--- a/anymap_ts/templates/maplibre.html
+++ b/anymap_ts/templates/maplibre.html
@@ -7,6 +7,8 @@
     <!-- MapLibre GL JS -->
     <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
     <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
+    <!-- deck.gl -->
+    <script src="https://unpkg.com/deck.gl@9/dist.min.js"></script>
     <!-- PMTiles (loaded via ESM import below) -->
     <!-- maplibre-gl-layer-control CSS -->
     <link href="https://unpkg.com/maplibre-gl-layer-control@0.14.1/dist/maplibre-gl-layer-control.css" rel="stylesheet" />
@@ -109,7 +111,9 @@
 
         function initDeckOverlay() {
             if (deckOverlay) return;
-            deckOverlay = new MapboxOverlay({ interleaved: true, layers: [] });
+            const Overlay = MapboxOverlay || (globalThis.deck && globalThis.deck.MapboxOverlay);
+            if (!Overlay) { console.error('deck.gl MapboxOverlay not available'); return; }
+            deckOverlay = new Overlay({ interleaved: true, layers: [] });
             map.addControl(deckOverlay);
             // Add invisible sentinel layer as ordering anchor
             if (!map.getLayer(DECK_SENTINEL_ID)) {
@@ -354,6 +358,13 @@
                 createDrawControl(drawControlConfig || state.controls['draw-control']);
             }
         });
+
+        function makeAccessor(value, defaultProp, fallbackFn) {
+            if (typeof value === 'string') return d => d[value];
+            if (typeof value === 'function') return value;
+            if (value !== undefined && value !== null) return value;
+            return fallbackFn || (d => d[defaultProp]);
+        }
 
         async function executeMethod(method, args, kwargs) {
             switch (method) {
@@ -1350,6 +1361,291 @@
                     cogLayerNames.delete(removeCogId);
                     updateDeckOverlay();
                     cogChangeCallbacks.forEach(cb => cb('remove', removeCogId));
+                    break;
+                }
+
+                case 'addScatterplotLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `scatterplot-${Date.now()}`;
+                    const layer = new deck.ScatterplotLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        stroked: kwargs.stroked !== false,
+                        filled: kwargs.filled !== false,
+                        radiusScale: kwargs.radiusScale ?? 1,
+                        radiusMinPixels: kwargs.radiusMinPixels ?? 1,
+                        radiusMaxPixels: kwargs.radiusMaxPixels ?? 100,
+                        lineWidthMinPixels: kwargs.lineWidthMinPixels ?? 1,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getRadius: makeAccessor(kwargs.getRadius ?? kwargs.radius, 'radius', () => 5),
+                        getFillColor: makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 200]),
+                        getLineColor: makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [255, 255, 255, 255])
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addArcLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `arc-${Date.now()}`;
+                    const layer = new deck.ArcLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        getWidth: makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
+                        getSourcePosition: makeAccessor(kwargs.getSourcePosition, 'source', d => d.source || d.from || d.sourcePosition),
+                        getTargetPosition: makeAccessor(kwargs.getTargetPosition, 'target', d => d.target || d.to || d.targetPosition),
+                        getSourceColor: makeAccessor(kwargs.getSourceColor ?? kwargs.sourceColor, 'sourceColor', () => [51, 136, 255, 255]),
+                        getTargetColor: makeAccessor(kwargs.getTargetColor ?? kwargs.targetColor, 'targetColor', () => [255, 136, 51, 255])
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addPathLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `path-${Date.now()}`;
+                    const layer = new deck.PathLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        widthScale: kwargs.widthScale ?? 1,
+                        widthMinPixels: kwargs.widthMinPixels ?? 1,
+                        getPath: makeAccessor(kwargs.getPath, 'path', d => d.path || d.coordinates),
+                        getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [51, 136, 255, 200]),
+                        getWidth: makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1)
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addPolygonLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `polygon-${Date.now()}`;
+                    const layer = new deck.PolygonLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.5,
+                        stroked: kwargs.stroked !== false,
+                        filled: kwargs.filled !== false,
+                        extruded: kwargs.extruded ?? false,
+                        wireframe: kwargs.wireframe ?? false,
+                        lineWidthMinPixels: kwargs.lineWidthMinPixels ?? 1,
+                        getPolygon: makeAccessor(kwargs.getPolygon, 'polygon', d => d.polygon || d.contour || d.coordinates),
+                        getElevation: makeAccessor(kwargs.getElevation ?? kwargs.elevation, 'elevation', () => 0),
+                        getFillColor: makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 128]),
+                        getLineColor: makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [0, 0, 255, 255]),
+                        getLineWidth: makeAccessor(kwargs.getLineWidth ?? kwargs.lineWidth, 'lineWidth', () => 1)
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addHexagonLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `hexagon-${Date.now()}`;
+                    const layer = new deck.HexagonLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        extruded: kwargs.extruded ?? true,
+                        radius: kwargs.radius ?? 1000,
+                        elevationScale: kwargs.elevationScale ?? 4,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        colorRange: kwargs.colorRange ?? [
+                            [1, 152, 189],
+                            [73, 227, 206],
+                            [216, 254, 181],
+                            [254, 237, 177],
+                            [254, 173, 84],
+                            [209, 55, 78]
+                        ]
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addHeatmapLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `heatmap-${Date.now()}`;
+                    const layer = new deck.HeatmapLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: false,
+                        opacity: kwargs.opacity ?? 1,
+                        radiusPixels: kwargs.radiusPixels ?? 30,
+                        intensity: kwargs.intensity ?? 1,
+                        threshold: kwargs.threshold ?? 0.05,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getWeight: makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
+                        colorRange: kwargs.colorRange ?? [
+                            [255, 255, 178, 25],
+                            [254, 217, 118, 85],
+                            [254, 178, 76, 127],
+                            [253, 141, 60, 170],
+                            [240, 59, 32, 212],
+                            [189, 0, 38, 255]
+                        ]
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addGridLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `grid-${Date.now()}`;
+                    const layer = new deck.GridLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        extruded: kwargs.extruded ?? true,
+                        cellSize: kwargs.cellSize ?? 200,
+                        elevationScale: kwargs.elevationScale ?? 4,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        colorRange: kwargs.colorRange ?? [
+                            [1, 152, 189],
+                            [73, 227, 206],
+                            [216, 254, 181],
+                            [254, 237, 177],
+                            [254, 173, 84],
+                            [209, 55, 78]
+                        ]
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addIconLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `icon-${Date.now()}`;
+                    const layer = new deck.IconLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 1,
+                        iconAtlas: kwargs.iconAtlas,
+                        iconMapping: kwargs.iconMapping,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getIcon: makeAccessor(kwargs.getIcon, 'icon', d => d.icon || 'marker'),
+                        getSize: makeAccessor(kwargs.getSize ?? kwargs.size, 'size', () => 20),
+                        getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [255, 255, 255, 255])
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addTextLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `text-${Date.now()}`;
+                    const layer = new deck.TextLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 1,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getText: makeAccessor(kwargs.getText, 'text', d => d.text || d.label || d.name || ''),
+                        getSize: makeAccessor(kwargs.getSize ?? kwargs.size, 'size', () => 12),
+                        getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [0, 0, 0, 255]),
+                        getAngle: makeAccessor(kwargs.getAngle, 'angle', () => 0),
+                        getTextAnchor: kwargs.getTextAnchor ?? 'middle',
+                        getAlignmentBaseline: kwargs.getAlignmentBaseline ?? 'center'
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addGeoJsonLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `geojson-${Date.now()}`;
+                    const layer = new deck.GeoJsonLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        stroked: kwargs.stroked !== false,
+                        filled: kwargs.filled !== false,
+                        extruded: kwargs.extruded ?? false,
+                        wireframe: kwargs.wireframe ?? false,
+                        lineWidthMinPixels: kwargs.lineWidthMinPixels ?? 1,
+                        pointRadiusMinPixels: kwargs.pointRadiusMinPixels ?? 2,
+                        getFillColor: makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 128]),
+                        getLineColor: makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [0, 0, 0, 255]),
+                        getLineWidth: makeAccessor(kwargs.getLineWidth ?? kwargs.lineWidth, 'lineWidth', () => 1),
+                        getPointRadius: makeAccessor(kwargs.getPointRadius ?? kwargs.pointRadius, 'pointRadius', () => 5),
+                        getElevation: makeAccessor(kwargs.getElevation ?? kwargs.elevation, 'elevation', () => 0)
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addContourLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `contour-${Date.now()}`;
+                    const layer = new deck.ContourLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 1,
+                        cellSize: kwargs.cellSize ?? 200,
+                        contours: kwargs.contours ?? [
+                            { threshold: 1, color: [255, 255, 255], strokeWidth: 1 },
+                            { threshold: 5, color: [51, 136, 255], strokeWidth: 2 },
+                            { threshold: 10, color: [0, 0, 255], strokeWidth: 3 }
+                        ],
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getWeight: makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1)
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'addScreenGridLayer': {
+                    initDeckOverlay();
+                    const id = kwargs.id || `screengrid-${Date.now()}`;
+                    const layer = new deck.ScreenGridLayer({
+                        id,
+                        data: kwargs.data,
+                        pickable: kwargs.pickable !== false,
+                        opacity: kwargs.opacity ?? 0.8,
+                        cellSizePixels: kwargs.cellSizePixels ?? 50,
+                        getPosition: makeAccessor(kwargs.getPosition, 'coordinates', d => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+                        getWeight: makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
+                        colorRange: kwargs.colorRange ?? [
+                            [255, 255, 178, 25],
+                            [254, 217, 118, 85],
+                            [254, 178, 76, 127],
+                            [253, 141, 60, 170],
+                            [240, 59, 32, 212],
+                            [189, 0, 38, 255]
+                        ]
+                    });
+                    deckLayers.set(id, layer);
+                    updateDeckOverlay();
+                    break;
+                }
+
+                case 'removeDeckLayer': {
+                    const removeDeckId = args[0];
+                    deckLayers.delete(removeDeckId);
+                    updateDeckOverlay();
                     break;
                 }
 

--- a/src/maplibre/MapLibreRenderer.ts
+++ b/src/maplibre/MapLibreRenderer.ts
@@ -1654,6 +1654,26 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
   // -------------------------------------------------------------------------
 
   /**
+   * Convert a value to an accessor function for deck.gl layers.
+   * Strings become property lookups, functions pass through, constants are returned as-is.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected makeAccessor(value: unknown, defaultProp: string, fallbackFn?: (d: any) => any): any {
+    if (typeof value === 'string') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (d: any) => d[value];
+    }
+    if (typeof value === 'function') {
+      return value;
+    }
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return fallbackFn || ((d: any) => d[defaultProp]);
+  }
+
+  /**
    * Initialize deck.gl overlay if not already created.
    */
   protected initializeDeckOverlay(): void {
@@ -2000,31 +2020,17 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     const id = kwargs.id as string || `arc-${Date.now()}`;
     const data = kwargs.data as unknown[];
 
-    // Helper to create accessor from string or use value directly
-    const makeAccessor = (value: unknown, defaultProp: string, fallbackFn?: (d: any) => any): any => {
-      if (typeof value === 'string') {
-        return (d: any) => d[value];
-      }
-      if (typeof value === 'function') {
-        return value;
-      }
-      if (value !== undefined && value !== null) {
-        return value; // Return arrays/numbers directly
-      }
-      return fallbackFn || ((d: any) => d[defaultProp]);
-    };
-
     const layer = new ArcLayer({
       id,
       data,
       pickable: kwargs.pickable !== false,
       opacity: kwargs.opacity as number ?? 0.8,
-      getWidth: makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
-      getSourcePosition: makeAccessor(kwargs.getSourcePosition, 'source', (d: any) => d.source || d.from || d.sourcePosition),
-      getTargetPosition: makeAccessor(kwargs.getTargetPosition, 'target', (d: any) => d.target || d.to || d.targetPosition),
-      getSourceColor: makeAccessor(kwargs.getSourceColor ?? kwargs.sourceColor, 'sourceColor', () => [51, 136, 255, 255]),
-      getTargetColor: makeAccessor(kwargs.getTargetColor ?? kwargs.targetColor, 'targetColor', () => [255, 136, 51, 255]),
-      getHeight: makeAccessor(kwargs.getHeight ?? kwargs.height, 'height', () => 1),
+      getWidth: this.makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
+      getSourcePosition: this.makeAccessor(kwargs.getSourcePosition, 'source', (d: any) => d.source || d.from || d.sourcePosition),
+      getTargetPosition: this.makeAccessor(kwargs.getTargetPosition, 'target', (d: any) => d.target || d.to || d.targetPosition),
+      getSourceColor: this.makeAccessor(kwargs.getSourceColor ?? kwargs.sourceColor, 'sourceColor', () => [51, 136, 255, 255]),
+      getTargetColor: this.makeAccessor(kwargs.getTargetColor ?? kwargs.targetColor, 'targetColor', () => [255, 136, 51, 255]),
+      getHeight: this.makeAccessor(kwargs.getHeight ?? kwargs.height, 'height', () => 1),
       greatCircle: kwargs.greatCircle as boolean ?? false,
     });
 
@@ -2062,29 +2068,15 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     const id = kwargs.id as string || `pointcloud-${Date.now()}`;
     const data = kwargs.data as unknown[];
 
-    // Helper to create accessor from string or use value directly
-    const makeAccessor = (value: unknown, defaultProp: string, fallbackFn?: (d: any) => any): any => {
-      if (typeof value === 'string') {
-        return (d: any) => d[value];
-      }
-      if (typeof value === 'function') {
-        return value;
-      }
-      if (value !== undefined && value !== null) {
-        return value; // Return arrays/numbers directly
-      }
-      return fallbackFn || ((d: any) => d[defaultProp]);
-    };
-
     const layerProps: Record<string, unknown> = {
       id,
       data,
       pickable: kwargs.pickable !== false,
       opacity: kwargs.opacity as number ?? 1,
       pointSize: kwargs.pointSize as number ?? 2,
-      getPosition: makeAccessor(kwargs.getPosition, 'position', (d: any) => d.position || d.coordinates || [d.x, d.y, d.z]),
-      getNormal: makeAccessor(kwargs.getNormal, 'normal', () => [0, 0, 1]),
-      getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [255, 255, 255, 255]),
+      getPosition: this.makeAccessor(kwargs.getPosition, 'position', (d: any) => d.position || d.coordinates || [d.x, d.y, d.z]),
+      getNormal: this.makeAccessor(kwargs.getNormal, 'normal', () => [0, 0, 1]),
+      getColor: this.makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [255, 255, 255, 255]),
       sizeUnits: kwargs.sizeUnits as 'pixels' | 'meters' | 'common' ?? 'pixels',
     };
 
@@ -2141,10 +2133,14 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       radiusMinPixels: kwargs.radiusMinPixels as number ?? 1,
       radiusMaxPixels: kwargs.radiusMaxPixels as number ?? 100,
       lineWidthMinPixels: kwargs.lineWidthMinPixels as number ?? 1,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-      getRadius: kwargs.getRadius ?? kwargs.radius ?? 5,
-      getFillColor: kwargs.getFillColor ?? kwargs.fillColor ?? [51, 136, 255, 200],
-      getLineColor: kwargs.getLineColor ?? kwargs.lineColor ?? [255, 255, 255, 255],
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
+      getRadius: this.makeAccessor(kwargs.getRadius ?? kwargs.radius, 'radius', () => 5),
+      getFillColor: this.makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 200]),
+      getLineColor: this.makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [255, 255, 255, 255]),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2169,9 +2165,9 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       opacity: kwargs.opacity as number ?? 0.8,
       widthScale: kwargs.widthScale as number ?? 1,
       widthMinPixels: kwargs.widthMinPixels as number ?? 1,
-      getPath: kwargs.getPath ?? ((d: any) => d.path || d.coordinates),
-      getColor: kwargs.getColor ?? kwargs.color ?? [51, 136, 255, 200],
-      getWidth: kwargs.getWidth ?? kwargs.width ?? 1,
+      getPath: this.makeAccessor(kwargs.getPath, 'path', (d: any) => d.path || d.coordinates),
+      getColor: this.makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [51, 136, 255, 200]),
+      getWidth: this.makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2199,11 +2195,11 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       extruded: kwargs.extruded as boolean ?? false,
       wireframe: kwargs.wireframe as boolean ?? false,
       lineWidthMinPixels: kwargs.lineWidthMinPixels as number ?? 1,
-      getPolygon: kwargs.getPolygon ?? ((d: any) => d.polygon || d.contour || d.coordinates),
-      getElevation: kwargs.getElevation ?? kwargs.elevation ?? 0,
-      getFillColor: kwargs.getFillColor ?? kwargs.fillColor ?? [51, 136, 255, 128],
-      getLineColor: kwargs.getLineColor ?? kwargs.lineColor ?? [0, 0, 255, 255],
-      getLineWidth: kwargs.getLineWidth ?? kwargs.lineWidth ?? 1,
+      getPolygon: this.makeAccessor(kwargs.getPolygon, 'polygon', (d: any) => d.polygon || d.contour || d.coordinates),
+      getElevation: this.makeAccessor(kwargs.getElevation ?? kwargs.elevation, 'elevation', () => 0),
+      getFillColor: this.makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 128]),
+      getLineColor: this.makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [0, 0, 255, 255]),
+      getLineWidth: this.makeAccessor(kwargs.getLineWidth ?? kwargs.lineWidth, 'lineWidth', () => 1),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2229,7 +2225,11 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       extruded: kwargs.extruded as boolean ?? true,
       radius: kwargs.radius as number ?? 1000,
       elevationScale: kwargs.elevationScale as number ?? 4,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
       colorRange: kwargs.colorRange ?? [
         [1, 152, 189],
         [73, 227, 206],
@@ -2263,8 +2263,12 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       radiusPixels: kwargs.radiusPixels as number ?? 30,
       intensity: kwargs.intensity as number ?? 1,
       threshold: kwargs.threshold as number ?? 0.05,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-      getWeight: kwargs.getWeight ?? kwargs.weight ?? 1,
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
+      getWeight: this.makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
       colorRange: (kwargs.colorRange ?? [
         [255, 255, 178, 25],
         [254, 217, 118, 85],
@@ -2298,7 +2302,11 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       extruded: kwargs.extruded as boolean ?? true,
       cellSize: kwargs.cellSize as number ?? 200,
       elevationScale: kwargs.elevationScale as number ?? 4,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
       colorRange: kwargs.colorRange ?? [
         [1, 152, 189],
         [73, 227, 206],
@@ -2331,10 +2339,14 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       opacity: kwargs.opacity as number ?? 1,
       iconAtlas: kwargs.iconAtlas as string,
       iconMapping: kwargs.iconMapping,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-      getIcon: kwargs.getIcon ?? ((d: any) => d.icon || 'marker'),
-      getSize: kwargs.getSize ?? kwargs.size ?? 20,
-      getColor: kwargs.getColor ?? kwargs.color ?? [255, 255, 255, 255],
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
+      getIcon: this.makeAccessor(kwargs.getIcon, 'icon', (d: any) => d.icon || 'marker'),
+      getSize: this.makeAccessor(kwargs.getSize ?? kwargs.size, 'size', () => 20),
+      getColor: this.makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [255, 255, 255, 255]),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2357,14 +2369,18 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       data,
       pickable: kwargs.pickable !== false,
       opacity: kwargs.opacity as number ?? 1,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-      getText: kwargs.getText ?? ((d: any) => d.text || d.label || d.name || ''),
-      getSize: kwargs.getSize ?? kwargs.size ?? 12,
-      getColor: kwargs.getColor ?? kwargs.color ?? [0, 0, 0, 255],
-      getAngle: kwargs.getAngle ?? 0,
-      getTextAnchor: kwargs.getTextAnchor ?? 'middle',
-      getAlignmentBaseline: kwargs.getAlignmentBaseline ?? 'center',
-    } as any);
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
+      getText: this.makeAccessor(kwargs.getText, 'text', (d: any) => d.text || d.label || d.name || ''),
+      getSize: this.makeAccessor(kwargs.getSize ?? kwargs.size, 'size', () => 12),
+      getColor: this.makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [0, 0, 0, 255]),
+      getAngle: this.makeAccessor(kwargs.getAngle, 'angle', () => 0),
+      getTextAnchor: (kwargs.getTextAnchor ?? 'middle') as any,
+      getAlignmentBaseline: (kwargs.getAlignmentBaseline ?? 'center') as any,
+    });
 
     this.deckLayers.set(id, layer);
     this.updateDeckOverlay();
@@ -2392,11 +2408,11 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       wireframe: kwargs.wireframe as boolean ?? false,
       lineWidthMinPixels: kwargs.lineWidthMinPixels as number ?? 1,
       pointRadiusMinPixels: kwargs.pointRadiusMinPixels as number ?? 2,
-      getFillColor: kwargs.getFillColor ?? kwargs.fillColor ?? [51, 136, 255, 128],
-      getLineColor: kwargs.getLineColor ?? kwargs.lineColor ?? [0, 0, 0, 255],
-      getLineWidth: kwargs.getLineWidth ?? kwargs.lineWidth ?? 1,
-      getPointRadius: kwargs.getPointRadius ?? kwargs.pointRadius ?? 5,
-      getElevation: kwargs.getElevation ?? kwargs.elevation ?? 0,
+      getFillColor: this.makeAccessor(kwargs.getFillColor ?? kwargs.fillColor, 'fillColor', () => [51, 136, 255, 128]),
+      getLineColor: this.makeAccessor(kwargs.getLineColor ?? kwargs.lineColor, 'lineColor', () => [0, 0, 0, 255]),
+      getLineWidth: this.makeAccessor(kwargs.getLineWidth ?? kwargs.lineWidth, 'lineWidth', () => 1),
+      getPointRadius: this.makeAccessor(kwargs.getPointRadius ?? kwargs.pointRadius, 'pointRadius', () => 5),
+      getElevation: this.makeAccessor(kwargs.getElevation ?? kwargs.elevation, 'elevation', () => 0),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2425,8 +2441,12 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
         { threshold: 5, color: [51, 136, 255], strokeWidth: 2 },
         { threshold: 10, color: [0, 0, 255], strokeWidth: 3 },
       ],
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-      getWeight: kwargs.getWeight ?? kwargs.weight ?? 1,
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
+      getWeight: this.makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2450,8 +2470,12 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       pickable: kwargs.pickable !== false,
       opacity: kwargs.opacity as number ?? 0.8,
       cellSizePixels: kwargs.cellSizePixels as number ?? 50,
-      getPosition: kwargs.getPosition ?? ((d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude]),
-      getWeight: kwargs.getWeight ?? kwargs.weight ?? 1,
+      getPosition: this.makeAccessor(
+        kwargs.getPosition,
+        'coordinates',
+        (d: any) => d.coordinates || d.position || [d.lng || d.longitude, d.lat || d.latitude],
+      ),
+      getWeight: this.makeAccessor(kwargs.getWeight ?? kwargs.weight, 'weight', () => 1),
       colorRange: (kwargs.colorRange ?? [
         [255, 255, 178, 25],
         [254, 217, 118, 85],
@@ -2477,20 +2501,6 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     const id = kwargs.id as string || `trips-${Date.now()}`;
     const data = kwargs.data as unknown[];
 
-    // Helper to create accessor from string or use value directly
-    const makeAccessor = (value: unknown, defaultProp: string, fallbackFn?: (d: any) => any): any => {
-      if (typeof value === 'string') {
-        return (d: any) => d[value];
-      }
-      if (typeof value === 'function') {
-        return value;
-      }
-      if (value !== undefined && value !== null) {
-        return value;
-      }
-      return fallbackFn || ((d: any) => d[defaultProp]);
-    };
-
     const layer = new TripsLayer({
       id,
       data,
@@ -2499,9 +2509,9 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       widthMinPixels: kwargs.widthMinPixels as number ?? 2,
       trailLength: kwargs.trailLength as number ?? 180,
       currentTime: kwargs.currentTime as number ?? 0,
-      getPath: makeAccessor(kwargs.getPath, 'waypoints', (d: any) => d.waypoints || d.path || d.coordinates),
-      getTimestamps: makeAccessor(kwargs.getTimestamps, 'timestamps', (d: any) => d.timestamps),
-      getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [253, 128, 93]),
+      getPath: this.makeAccessor(kwargs.getPath, 'waypoints', (d: any) => d.waypoints || d.path || d.coordinates),
+      getTimestamps: this.makeAccessor(kwargs.getTimestamps, 'timestamps', (d: any) => d.timestamps),
+      getColor: this.makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [253, 128, 93]),
     } as any);
 
     this.deckLayers.set(id, layer);
@@ -2519,30 +2529,16 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     const id = kwargs.id as string || `line-${Date.now()}`;
     const data = kwargs.data as unknown[];
 
-    // Helper to create accessor from string or use value directly
-    const makeAccessor = (value: unknown, defaultProp: string, fallbackFn?: (d: any) => any): any => {
-      if (typeof value === 'string') {
-        return (d: any) => d[value];
-      }
-      if (typeof value === 'function') {
-        return value;
-      }
-      if (value !== undefined && value !== null) {
-        return value;
-      }
-      return fallbackFn || ((d: any) => d[defaultProp]);
-    };
-
     const layer = new LineLayer({
       id,
       data,
       pickable: kwargs.pickable !== false,
       opacity: kwargs.opacity as number ?? 0.8,
       widthMinPixels: kwargs.widthMinPixels as number ?? 1,
-      getSourcePosition: makeAccessor(kwargs.getSourcePosition, 'sourcePosition', (d: any) => d.sourcePosition || d.source || d.from),
-      getTargetPosition: makeAccessor(kwargs.getTargetPosition, 'targetPosition', (d: any) => d.targetPosition || d.target || d.to),
-      getColor: makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [51, 136, 255, 200]),
-      getWidth: makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
+      getSourcePosition: this.makeAccessor(kwargs.getSourcePosition, 'sourcePosition', (d: any) => d.sourcePosition || d.source || d.from),
+      getTargetPosition: this.makeAccessor(kwargs.getTargetPosition, 'targetPosition', (d: any) => d.targetPosition || d.target || d.to),
+      getColor: this.makeAccessor(kwargs.getColor ?? kwargs.color, 'color', () => [51, 136, 255, 200]),
+      getWidth: this.makeAccessor(kwargs.getWidth ?? kwargs.width, 'width', () => 1),
     } as any);
 
     this.deckLayers.set(id, layer);


### PR DESCRIPTION
## Summary
- Fix deck.gl layers (TextLayer, HeatmapLayer, ArcLayer, etc.) not rendering in HTML exports for both `MapLibreMap` and `DeckGLMap` by adding `makeAccessor` to convert string accessors to proper functions
- Add all missing deck.gl layer case handlers to `maplibre.html` template (previously only COG layers were supported)
- Add layer control and control grid support to `deckgl.html` template with proper basemap ordering

## Details

### Root cause
When Python sends string accessors like `getPosition="coordinates"` or `getText="text"`, these need to be converted to accessor functions (`d => d["coordinates"]`). The `DeckGLRenderer` (widget) did this via `makeAccessor()`, but `MapLibreRenderer` and both HTML templates did not.

### Changes

**`src/maplibre/MapLibreRenderer.ts`**
- Added `protected makeAccessor()` method to the class
- Updated all deck.gl layer handlers to use `this.makeAccessor()` instead of passing raw string kwargs

**`anymap_ts/templates/maplibre.html`**
- Added `<script src="deck.gl@9/dist.min.js">` for standard deck.gl layers
- Added `makeAccessor()` helper function
- Added 13 deck.gl layer case handlers (TextLayer, ScatterplotLayer, ArcLayer, etc.)
- Added `removeDeckLayer` handler
- Updated `initDeckOverlay()` to fallback to `deck.MapboxOverlay` from the global bundle

**`anymap_ts/templates/deckgl.html`**
- Added `makeAccessor()` helper and updated all layer handlers to use it
- Added layer control support (CSS/JS imports, `addLayerControl` case, `createLayerControl()`, deck layer adapter)
- Added control grid support (`addControlGrid` case, deferred initialization)
- Fixed basemap layer ordering (inserted below deck sentinel) and naming (removed "Basemap" prefix)

## Test plan
- [ ] Run `text_layer.ipynb` with `DeckGLMap` -- verify text labels in JupyterLab and HTML export
- [ ] Run `text_layer.ipynb` with `MapLibreMap` -- verify text labels in JupyterLab and HTML export
- [ ] Verify layer control appears in DeckGLMap HTML export with correct layer order
- [ ] Test arc/heatmap layers with both map types

Fixes #148