### PR TITLE
feat: add GeoAgent control to MapLibre integration

### DIFF
--- a/anymap_ts/maplibre.py
+++ b/anymap_ts/maplibre.py
@@ -50,6 +50,9 @@ class MapLibreMap(MapWidget):
     # Layer tracking
     _layer_dict = traitlets.Dict({}).tag(sync=True)
 
+    # Latest state emitted by maplibre-gl-geoagent
+    _geoagent_state = traitlets.Dict({}).tag(sync=True)
+
     def __init__(
         self,
         center: Tuple[float, float] = (0.0, 0.0),
@@ -128,6 +131,10 @@ class MapLibreMap(MapWidget):
                     )
                 elif control_name == "control-grid":
                     self.add_control_grid(
+                        **(config if isinstance(config, dict) else {})
+                    )
+                elif control_name in ("geoagent", "geoagent-control"):
+                    self.add_geoagent_control(
                         **(config if isinstance(config, dict) else {})
                     )
                 else:
@@ -4361,6 +4368,112 @@ class MapLibreMap(MapWidget):
             controls = dict(self._controls)
             del controls[control_type]
             self._controls = controls
+
+    def add_geoagent_control(
+        self,
+        position: str = "top-right",
+        collapsed: bool = True,
+        title: str = "GeoAgent",
+        panel_width: int = 390,
+        panel_min_width: int = 320,
+        panel_max_width: int = 720,
+        default_provider: str = "openai-responses",
+        default_model: Optional[Union[str, Dict[str, str]]] = None,
+        storage_prefix: str = "geoagent.maplibre",
+        allow_code_execution_default: bool = True,
+        allow_destructive_tools_default: bool = True,
+        show_permission_toggles: bool = False,
+        basemaps: Optional[Dict[str, Any]] = None,
+        class_name: str = "",
+        **kwargs,
+    ) -> None:
+        """Add the maplibre-gl-geoagent AI assistant control.
+
+        The control runs provider SDKs in the browser and lets users enter API
+        keys in the panel. Keys and model preferences are stored in browser
+        ``sessionStorage`` using ``storage_prefix``.
+
+        Args:
+            position: Control position ('top-left', 'top-right', 'bottom-left',
+                or 'bottom-right').
+            collapsed: Whether the panel starts collapsed.
+            title: Panel title and control button label.
+            panel_width: Initial floating panel width in pixels.
+            panel_min_width: Minimum resizable panel width in pixels.
+            panel_max_width: Maximum resizable panel width in pixels.
+            default_provider: Initial provider. Supported values include
+                'openai-responses', 'openai-chat', 'anthropic', 'google',
+                and 'bedrock'.
+            default_model: Default model for all providers, or a provider to
+                model mapping.
+            storage_prefix: Prefix for browser sessionStorage keys.
+            allow_code_execution_default: Whether the MapLibre JavaScript tool
+                starts enabled.
+            allow_destructive_tools_default: Whether layer removal tools start
+                enabled.
+            show_permission_toggles: Whether to show permission toggles.
+            basemaps: Optional basemap style registry exposed to the agent.
+            class_name: Extra CSS class for the control container.
+            **kwargs: Additional maplibre-gl-geoagent options, using camelCase.
+
+        Example:
+            >>> m = MapLibreMap()
+            >>> m.add_geoagent_control(
+            ...     position="top-left",
+            ...     collapsed=False,
+            ...     default_provider="openai-responses",
+            ... )
+        """
+        position = self._validate_position(position)
+        js_kwargs: Dict[str, Any] = {
+            "position": position,
+            "collapsed": collapsed,
+            "title": title,
+            "panelWidth": panel_width,
+            "panelMinWidth": panel_min_width,
+            "panelMaxWidth": panel_max_width,
+            "defaultProvider": default_provider,
+            "storagePrefix": storage_prefix,
+            "allowCodeExecutionDefault": allow_code_execution_default,
+            "allowDestructiveToolsDefault": allow_destructive_tools_default,
+            "showPermissionToggles": show_permission_toggles,
+            **kwargs,
+        }
+        if default_model is not None:
+            js_kwargs["defaultModel"] = default_model
+        if basemaps is not None:
+            js_kwargs["basemaps"] = basemaps
+        if class_name:
+            js_kwargs["className"] = class_name
+
+        self.call_js_method("addGeoAgentControl", **js_kwargs)
+        self._controls = {
+            **self._controls,
+            "geoagent-control": js_kwargs,
+        }
+
+    def remove_geoagent_control(self) -> None:
+        """Remove the GeoAgent control."""
+        self.call_js_method("removeGeoAgentControl")
+        if "geoagent-control" in self._controls:
+            controls = dict(self._controls)
+            del controls["geoagent-control"]
+            self._controls = controls
+        self._geoagent_state = {}
+
+    def set_geoagent_state(self, **state: Any) -> None:
+        """Update the GeoAgent control state from Python.
+
+        Common state keys include ``collapsed``, ``panelWidth``,
+        ``providerId``, ``modelId``, ``bedrockRegion``,
+        ``allowCodeExecution``, and ``allowDestructiveTools``.
+        """
+        self.call_js_method("setGeoAgentState", **state)
+
+    @property
+    def geoagent_state(self) -> Dict[str, Any]:
+        """Latest GeoAgent state emitted by the browser control."""
+        return dict(self._geoagent_state)
 
     def add_layer_control(
         self,

--- a/anymap_ts/templates/maplibre.html
+++ b/anymap_ts/templates/maplibre.html
@@ -14,6 +14,8 @@
     <link href="https://unpkg.com/maplibre-gl-layer-control@0.14.1/dist/maplibre-gl-layer-control.css" rel="stylesheet" />
     <!-- maplibre-gl-components CSS -->
     <link href="https://unpkg.com/maplibre-gl-components@0.16.2/dist/maplibre-gl-components.css" rel="stylesheet" />
+    <!-- maplibre-gl-geoagent CSS -->
+    <link href="https://unpkg.com/maplibre-gl-geoagent@0.3.1/dist/maplibre-gl-geoagent.css" rel="stylesheet" />
     <!-- Geoman for drawing -->
     <script src="https://cdn.jsdelivr.net/npm/@geoman-io/maplibre-geoman-free@0.6.1/dist/maplibre-geoman.umd.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/@geoman-io/maplibre-geoman-free@0.6.1/dist/maplibre-geoman.css" rel="stylesheet" />
@@ -36,8 +38,10 @@
         let layerControlConfig = null;
         let drawControlConfig = null;
         let controlGridConfig = null;
+        let geoAgentControlConfig = null;
         let controlGridAdded = false;
         let layerControlAdded = false;
+        let geoAgentControl = null;
         let timeSliderContainer = null;
 
         // Route animation state
@@ -47,6 +51,7 @@
         let LayerControl = null;
         let addControlGridFn = null;
         let GeoEditorClass = null;
+        let GeoAgentControlClass = null;
 
         const lcPromise = import('https://esm.sh/maplibre-gl-layer-control@0.14.1')
             .then(mod => { LayerControl = mod.LayerControl; })
@@ -59,6 +64,10 @@
         const gePromise = import('https://esm.sh/maplibre-gl-geo-editor@0.7.3')
             .then(mod => { GeoEditorClass = mod.GeoEditor; })
             .catch(() => console.warn('GeoEditor library unavailable — falling back to Geoman'));
+
+        const gaPromise = import('https://esm.sh/maplibre-gl-geoagent@0.3.1')
+            .then(mod => { GeoAgentControlClass = mod.GeoAgentControl; })
+            .catch(() => console.warn('GeoAgent library unavailable — GeoAgent control will be skipped'));
 
         // Inline route animation helpers (Haversine-based, no CDN dependency)
         function _haversineDistance(a, b) {
@@ -365,7 +374,7 @@
             }
 
             // 2. Wait for optional imports to settle
-            await Promise.allSettled([lcPromise, cgPromise, gePromise]);
+            await Promise.allSettled([lcPromise, cgPromise, gePromise, gaPromise]);
 
             // 3. Add layer control if library loaded and configured
             if (!layerControlAdded && (layerControlConfig || (state.controls && state.controls['layer-control']))) {
@@ -400,7 +409,13 @@
                 }
             }
 
-            // 5. Add draw control if configured
+            // 5. Add GeoAgent control if library loaded and configured
+            if (!geoAgentControl && (geoAgentControlConfig || (state.controls && state.controls['geoagent-control']))) {
+                const config = geoAgentControlConfig || state.controls['geoagent-control'];
+                createGeoAgentControl(config);
+            }
+
+            // 6. Add draw control if configured
             if (drawControlConfig || (state.controls && state.controls['draw-control'])) {
                 createDrawControl(drawControlConfig || state.controls['draw-control']);
             }
@@ -527,6 +542,13 @@
                                 compact: kwargs.compact !== false
                             });
                             break;
+                        case 'geoagent':
+                        case 'geoagent-control':
+                            geoAgentControlConfig = kwargs;
+                            if (GeoAgentControlClass) {
+                                createGeoAgentControl(geoAgentControlConfig);
+                            }
+                            break;
                     }
                     if (control) {
                         map.addControl(control, position);
@@ -549,6 +571,29 @@
                 case 'addControlGrid': {
                     // Store config for later (add after layer control)
                     controlGridConfig = kwargs;
+                    break;
+                }
+
+                case 'addGeoAgentControl': {
+                    geoAgentControlConfig = kwargs;
+                    if (GeoAgentControlClass) {
+                        createGeoAgentControl(geoAgentControlConfig);
+                    }
+                    break;
+                }
+
+                case 'removeGeoAgentControl': {
+                    if (geoAgentControl) {
+                        map.removeControl(geoAgentControl);
+                        geoAgentControl = null;
+                    }
+                    break;
+                }
+
+                case 'setGeoAgentState': {
+                    if (geoAgentControl && typeof geoAgentControl.setState === 'function') {
+                        geoAgentControl.setState(kwargs);
+                    }
                     break;
                 }
 
@@ -2201,6 +2246,59 @@
             map.addControl(layerControlInstance, position);
             syncLayerControlOrder();
             scheduleLayerControlOrderSync();
+        }
+
+        function createGeoAgentControl(config) {
+            if (!GeoAgentControlClass) {
+                console.warn('GeoAgent library unavailable — skipping GeoAgent control');
+                return;
+            }
+            if (geoAgentControl) {
+                map.removeControl(geoAgentControl);
+                geoAgentControl = null;
+            }
+
+            const position = config.position || 'top-right';
+            geoAgentControl = new GeoAgentControlClass({
+                ...config,
+                position,
+            });
+            map.addControl(geoAgentControl, position);
+            installGeoAgentEventGuards(geoAgentControl);
+        }
+
+        function installGeoAgentEventGuards(control) {
+            const elements = [
+                typeof control.getContainer === 'function' ? control.getContainer() : null,
+                typeof control.getPanel === 'function' ? control.getPanel() : null,
+            ].filter(Boolean);
+            const guardedEvents = [
+                'keydown',
+                'keypress',
+                'keyup',
+                'beforeinput',
+                'input',
+                'compositionstart',
+                'compositionupdate',
+                'compositionend',
+                'mousedown',
+                'mouseup',
+                'click',
+                'dblclick',
+                'pointerdown',
+                'pointerup',
+                'touchstart',
+                'touchend',
+                'wheel',
+            ];
+            const stop = event => event.stopPropagation();
+            for (const element of elements) {
+                if (element.dataset.anymapGeoagentEventGuards === 'true') continue;
+                element.dataset.anymapGeoagentEventGuards = 'true';
+                for (const eventName of guardedEvents) {
+                    element.addEventListener(eventName, stop);
+                }
+            }
         }
 
         function createDrawControl(config) {

--- a/docs/maplibre/geoagent.ipynb
+++ b/docs/maplibre/geoagent.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/anymap-ts/blob/main/docs/maplibre/geoagent.ipynb)\n",
+    "[![Open in Notebook.link](https://img.shields.io/badge/notebook-link-e2d610?logo=jupyter&logoColor=white)](https://notebook.link/opengeos/anymap-ts/blob/main/docs/maplibre/geoagent.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "# GeoAgent Control\n",
+    "\n",
+    "This notebook demonstrates the `maplibre-gl-geoagent` control in `anymap-ts`. The control runs in the browser, stores provider settings in browser session storage, and can inspect or operate on the live MapLibre map through browser map tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install anymap-ts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Basic GeoAgent Control\n",
+    "\n",
+    "The browser panel lets users choose a provider, enter an API key, and select a model. API keys are not passed through Python; they are entered and stored in the browser session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "m = Map(center=[-122.431, 37.789], zoom=12, height=\"720px\")\n",
+    "m.add_geoagent_control(\n",
+    "    position=\"top-left\",\n",
+    "    collapsed=False,\n",
+    "    panel_width=420,\n",
+    "    allow_code_execution_default=False,\n",
+    "    allow_destructive_tools_default=False,\n",
+    "    show_permission_toggles=False,\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Add Map Data for the Agent\n",
+    "\n",
+    "Add a few visible layers before opening the assistant. The agent can inspect layer names, query rendered features, move the camera, change basemaps, and create map annotations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anymap_ts import Map\n",
+    "\n",
+    "landmarks = {\n",
+    "    \"type\": \"FeatureCollection\",\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"type\": \"Feature\",\n",
+    "            \"geometry\": {\"type\": \"Point\", \"coordinates\": [-122.4194, 37.7749]},\n",
+    "            \"properties\": {\"name\": \"San Francisco City Hall\", \"category\": \"civic\"},\n",
+    "        },\n",
+    "        {\n",
+    "            \"type\": \"Feature\",\n",
+    "            \"geometry\": {\"type\": \"Point\", \"coordinates\": [-122.3937, 37.7955]},\n",
+    "            \"properties\": {\"name\": \"Ferry Building\", \"category\": \"landmark\"},\n",
+    "        },\n",
+    "        {\n",
+    "            \"type\": \"Feature\",\n",
+    "            \"geometry\": {\"type\": \"Point\", \"coordinates\": [-122.4783, 37.8199]},\n",
+    "            \"properties\": {\"name\": \"Golden Gate Bridge\", \"category\": \"landmark\"},\n",
+    "        },\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "sample_area = {\n",
+    "    \"type\": \"FeatureCollection\",\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"type\": \"Feature\",\n",
+    "            \"geometry\": {\n",
+    "                \"type\": \"Polygon\",\n",
+    "                \"coordinates\": [\n",
+    "                    [\n",
+    "                        [-122.431, 37.789],\n",
+    "                        [-122.402, 37.789],\n",
+    "                        [-122.402, 37.773],\n",
+    "                        [-122.431, 37.773],\n",
+    "                        [-122.431, 37.789],\n",
+    "                    ]\n",
+    "                ],\n",
+    "            },\n",
+    "            \"properties\": {\"name\": \"Central SF sample area\"},\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "m = Map(center=[-122.431, 37.789], zoom=12, height=\"720px\")\n",
+    "m.add_geojson(\n",
+    "    sample_area,\n",
+    "    name=\"sf-sample-area\",\n",
+    "    layer_type=\"fill\",\n",
+    "    paint={\"fill-color\": \"#2f9e44\", \"fill-opacity\": 0.25},\n",
+    ")\n",
+    "m.add_geojson(\n",
+    "    landmarks,\n",
+    "    name=\"sf-landmarks\",\n",
+    "    layer_type=\"circle\",\n",
+    "    paint={\n",
+    "        \"circle-color\": \"#0b7285\",\n",
+    "        \"circle-radius\": 8,\n",
+    "        \"circle-stroke-color\": \"#ffffff\",\n",
+    "        \"circle-stroke-width\": 2,\n",
+    "    },\n",
+    ")\n",
+    "m.add_geoagent_control(\n",
+    "    position=\"top-left\",\n",
+    "    collapsed=False,\n",
+    "    panel_width=420,\n",
+    "    default_provider=\"openai-responses\",\n",
+    "    allow_code_execution_default=False,\n",
+    "    allow_destructive_tools_default=False,\n",
+    "    show_permission_toggles=True,\n",
+    "    basemaps={\n",
+    "        \"Liberty\": \"https://tiles.openfreemap.org/styles/liberty\",\n",
+    "        \"Positron\": \"https://basemaps.cartocdn.com/gl/positron-gl-style/style.json\",\n",
+    "        \"DarkMatter\": \"https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json\",\n",
+    "    },\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Read and Update GeoAgent State\n",
+    "\n",
+    "The widget keeps the latest browser-side control state in `geoagent_state`. State updates are asynchronous, so run the state-reading cell after interacting with the panel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.geoagent_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.set_geoagent_state(collapsed=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Remove the Control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.remove_geoagent_control()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -310,6 +310,11 @@
             <p>Street-level imagery viewer with camera trajectories and photo navigation.</p>
             <span class="tag">Control</span><span class="tag sub">Photos</span>
           </a>
+          <a href="./maplibre/geoagent_control.html" class="example-card">
+            <h3>GeoAgent Control</h3>
+            <p>Browser AI assistant control for inspecting and operating on a live MapLibre map.</p>
+            <span class="tag">Control</span><span class="tag sub">AI</span>
+          </a>
         </div>
       </div>
 

--- a/examples/maplibre/geoagent-main.ts
+++ b/examples/maplibre/geoagent-main.ts
@@ -1,0 +1,136 @@
+import maplibregl from 'maplibre-gl';
+import { LayerControl } from 'maplibre-gl-layer-control';
+import { GeoAgentControl } from 'maplibre-gl-geoagent';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import 'maplibre-gl-layer-control/style.css';
+import 'maplibre-gl-geoagent/style.css';
+
+const BASEMAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+
+const cityData = {
+  type: 'FeatureCollection' as const,
+  features: [
+    {
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [-122.4194, 37.7749] },
+      properties: { name: 'San Francisco City Hall', category: 'civic' },
+    },
+    {
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [-122.3937, 37.7955] },
+      properties: { name: 'Ferry Building', category: 'landmark' },
+    },
+    {
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [-122.4783, 37.8199] },
+      properties: { name: 'Golden Gate Bridge', category: 'landmark' },
+    },
+  ],
+};
+
+const neighborhoodData = {
+  type: 'FeatureCollection' as const,
+  features: [
+    {
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Polygon' as const,
+        coordinates: [[
+          [-122.431, 37.789],
+          [-122.402, 37.789],
+          [-122.402, 37.773],
+          [-122.431, 37.773],
+          [-122.431, 37.789],
+        ]],
+      },
+      properties: { name: 'Central SF sample area' },
+    },
+  ],
+};
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP_STYLE,
+  center: [-122.431, 37.789],
+  zoom: 12,
+  maxPitch: 85,
+  canvasContextAttributes: { preserveDrawingBuffer: true },
+});
+
+map.addControl(new maplibregl.NavigationControl(), 'top-right');
+map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }), 'bottom-right');
+
+const layerControl = new LayerControl({
+  collapsed: true,
+  layers: ['sf-sample-area', 'sf-landmarks'],
+  panelWidth: 320,
+  panelMinWidth: 240,
+  panelMaxWidth: 420,
+  basemapStyleUrl: BASEMAP_STYLE,
+});
+map.addControl(layerControl, 'top-right');
+
+map.on('load', () => {
+  map.addSource('sf-landmarks-source', {
+    type: 'geojson',
+    data: cityData,
+  });
+
+  map.addLayer({
+    id: 'sf-landmarks',
+    type: 'circle',
+    source: 'sf-landmarks-source',
+    paint: {
+      'circle-color': [
+        'match',
+        ['get', 'category'],
+        'civic', '#d9480f',
+        'landmark', '#0b7285',
+        '#495057',
+      ],
+      'circle-radius': 8,
+      'circle-stroke-color': '#ffffff',
+      'circle-stroke-width': 2,
+    },
+  });
+
+  map.addSource('sf-sample-area-source', {
+    type: 'geojson',
+    data: neighborhoodData,
+  });
+
+  map.addLayer({
+    id: 'sf-sample-area',
+    type: 'fill',
+    source: 'sf-sample-area-source',
+    paint: {
+      'fill-color': '#2f9e44',
+      'fill-opacity': 0.25,
+      'fill-outline-color': '#2b8a3e',
+    },
+  }, 'sf-landmarks');
+
+  const geoAgent = new GeoAgentControl({
+    title: 'GeoAgent',
+    collapsed: false,
+    position: 'top-left',
+    panelWidth: 420,
+    panelMinWidth: 340,
+    panelMaxWidth: 680,
+    defaultProvider: 'openai-responses',
+    allowCodeExecutionDefault: false,
+    allowDestructiveToolsDefault: false,
+    showPermissionToggles: false,
+    basemaps: {
+      Liberty: BASEMAP_STYLE,
+      Positron: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+      DarkMatter: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+    },
+  });
+
+  geoAgent.on('statechange', (event) => {
+    console.log('GeoAgent state changed:', event.state);
+  });
+
+  map.addControl(geoAgent, 'top-left');
+});

--- a/examples/maplibre/geoagent_control.html
+++ b/examples/maplibre/geoagent_control.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GeoAgent Control - anymap-ts Example</title>
+  <link href="https://unpkg.com/maplibre-gl@5.18.0/dist/maplibre-gl.css" rel="stylesheet">
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <div class="header">
+    <h1>GeoAgent Control</h1>
+    <a href="../">← Back to Examples</a>
+  </div>
+  <div id="map"></div>
+  <script type="module" src="./geoagent-main.ts"></script>
+</body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
           - maplibre/feature_query_filter.ipynb
           - maplibre/field_boundary.ipynb
           - maplibre/flatgeobuf.ipynb
+          - maplibre/geoagent.ipynb
           - maplibre/geophoto.ipynb
           - maplibre/globe_projection.ipynb
           - maplibre/image_overlay.ipynb

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "maplibre-gl": ">=5.14.0",
     "maplibre-gl-components": "^0.16.3",
     "maplibre-gl-geo-editor": "^0.7.3",
+    "maplibre-gl-geoagent": "^0.3.1",
     "maplibre-gl-geophoto": "^0.2.0",
     "maplibre-gl-layer-control": "^0.14.1",
     "maplibre-gl-lidar": "^0.11.1",

--- a/src/maplibre/MapLibreRenderer.ts
+++ b/src/maplibre/MapLibreRenderer.ts
@@ -65,6 +65,11 @@ import { COGLayerAdapter, ZarrLayerAdapter, DeckLayerAdapter, MarkerLayerAdapter
 import { LidarControl, LidarLayerAdapter } from 'maplibre-gl-lidar';
 import type { LidarControlOptions, LidarLayerOptions, LidarColorScheme } from '../types/lidar';
 import { GeoPhotoControl } from 'maplibre-gl-geophoto';
+import {
+  GeoAgentControl,
+  type GeoAgentControlEventHandler,
+  type GeoAgentControlOptions,
+} from 'maplibre-gl-geoagent';
 
 // Import controls from maplibre-gl-components
 import {
@@ -164,6 +169,9 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
   protected measureControl: MeasureControl | null = null;
   protected printControl: PrintControl | null = null;
   protected geoPhotoControl: GeoPhotoControl | null = null;
+  protected geoAgentControl: GeoAgentControl | null = null;
+  private geoAgentStateHandler: GeoAgentControlEventHandler | null = null;
+  private geoAgentEventGuardCleanup: (() => void) | null = null;
 
   // Route animations
   protected animations: globalThis.Map<string, {
@@ -567,6 +575,11 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     // GeoPhoto Control
     this.registerMethod('addGeoPhotoControl', this.handleAddGeoPhotoControl.bind(this));
     this.registerMethod('removeGeoPhotoControl', this.handleRemoveGeoPhotoControl.bind(this));
+
+    // GeoAgent control
+    this.registerMethod('addGeoAgentControl', this.handleAddGeoAgentControl.bind(this));
+    this.registerMethod('removeGeoAgentControl', this.handleRemoveGeoAgentControl.bind(this));
+    this.registerMethod('setGeoAgentState', this.handleSetGeoAgentState.bind(this));
     this.registerMethod('loadGeoPhotoZip', this.handleLoadGeoPhotoZip.bind(this));
     this.registerMethod('loadGeoPhotoUrls', this.handleLoadGeoPhotoUrls.bind(this));
     this.registerMethod('geoPhotoSelectCamera', this.handleGeoPhotoSelectCamera.bind(this));
@@ -1066,6 +1079,10 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       case 'globe':
         control = new GlobeControl();
         break;
+      case 'geoagent':
+      case 'geoagent-control':
+        this.handleAddGeoAgentControl(args, kwargs);
+        return;
     }
 
     if (control) {
@@ -1078,6 +1095,11 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
   private handleRemoveControl(args: unknown[], kwargs: Record<string, unknown>): void {
     if (!this.map) return;
     const [controlType] = args as [string];
+
+    if (controlType === 'geoagent' || controlType === 'geoagent-control') {
+      this.handleRemoveGeoAgentControl(args, kwargs);
+      return;
+    }
 
     const control = this.controlsMap.get(controlType);
     if (control) {
@@ -6031,6 +6053,118 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
     this.geoPhotoControl = null;
   }
 
+  // -------------------------------------------------------------------------
+  // GeoAgent Control handlers
+  // -------------------------------------------------------------------------
+
+  private handleAddGeoAgentControl(_args: unknown[], kwargs: Record<string, unknown>): void {
+    if (!this.map) return;
+
+    if (this.geoAgentControl) {
+      this.handleRemoveGeoAgentControl([], {});
+    }
+
+    const position = (kwargs.position as ControlPosition) || 'top-right';
+    const options = {
+      ...kwargs,
+      position,
+    } as GeoAgentControlOptions;
+
+    this.geoAgentControl = new GeoAgentControl(options);
+    this.geoAgentStateHandler = (event) => {
+      this.model.set('_geoagent_state', event.state);
+      this.model.save_changes();
+      this.sendEvent(`geoagent:${event.type}`, event.state);
+    };
+    this.geoAgentControl.on('collapse', this.geoAgentStateHandler);
+    this.geoAgentControl.on('expand', this.geoAgentStateHandler);
+    this.geoAgentControl.on('statechange', this.geoAgentStateHandler);
+
+    this.map.addControl(this.geoAgentControl as unknown as maplibregl.IControl, position);
+    this.installGeoAgentEventGuards(this.geoAgentControl);
+    this.controlsMap.set('geoagent-control', this.geoAgentControl as unknown as maplibregl.IControl);
+    this.stateManager.addControl('geoagent-control', 'geoagent-control', position, kwargs);
+
+    this.model.set('_geoagent_state', this.geoAgentControl.getState());
+    this.model.save_changes();
+  }
+
+  private handleRemoveGeoAgentControl(_args: unknown[], _kwargs: Record<string, unknown>): void {
+    if (!this.map || !this.geoAgentControl) return;
+
+    if (this.geoAgentStateHandler) {
+      this.geoAgentControl.off('collapse', this.geoAgentStateHandler);
+      this.geoAgentControl.off('expand', this.geoAgentStateHandler);
+      this.geoAgentControl.off('statechange', this.geoAgentStateHandler);
+      this.geoAgentStateHandler = null;
+    }
+    this.geoAgentEventGuardCleanup?.();
+    this.geoAgentEventGuardCleanup = null;
+
+    this.map.removeControl(this.geoAgentControl as unknown as maplibregl.IControl);
+    this.controlsMap.delete('geoagent-control');
+    this.stateManager.removeControl('geoagent-control');
+    this.geoAgentControl = null;
+    this.model.set('_geoagent_state', {});
+    this.model.save_changes();
+  }
+
+  private handleSetGeoAgentState(_args: unknown[], kwargs: Record<string, unknown>): void {
+    if (!this.geoAgentControl) {
+      console.warn('GeoAgent control not added. Call addGeoAgentControl first.');
+      return;
+    }
+    this.geoAgentControl.setState(kwargs);
+    this.model.set('_geoagent_state', this.geoAgentControl.getState());
+    this.model.save_changes();
+  }
+
+  private installGeoAgentEventGuards(control: GeoAgentControl): void {
+    this.geoAgentEventGuardCleanup?.();
+
+    const elements = [
+      control.getContainer?.(),
+      control.getPanel?.(),
+    ].filter((element): element is HTMLElement => element instanceof HTMLElement);
+
+    const stop = (event: Event) => {
+      event.stopPropagation();
+    };
+    const guardedEvents = [
+      'keydown',
+      'keypress',
+      'keyup',
+      'beforeinput',
+      'input',
+      'compositionstart',
+      'compositionupdate',
+      'compositionend',
+      'mousedown',
+      'mouseup',
+      'click',
+      'dblclick',
+      'pointerdown',
+      'pointerup',
+      'touchstart',
+      'touchend',
+      'wheel',
+    ];
+
+    for (const element of elements) {
+      for (const eventName of guardedEvents) {
+        element.addEventListener(eventName, stop);
+      }
+    }
+
+    this.geoAgentEventGuardCleanup = () => {
+      for (const element of elements) {
+        for (const eventName of guardedEvents) {
+          element.removeEventListener(eventName, stop);
+        }
+      }
+    };
+  }
+
   private async handleLoadGeoPhotoZip(_args: unknown[], kwargs: Record<string, unknown>): Promise<void> {
     if (!this.geoPhotoControl) {
       console.warn('GeoPhoto control not added. Call addGeoPhotoControl first.');
@@ -6439,6 +6573,21 @@ export class MapLibreRenderer extends BaseMapRenderer<MapLibreMap> {
       this.geoPhotoControl.clearData();
       this.map.removeControl(this.geoPhotoControl as unknown as maplibregl.IControl);
       this.geoPhotoControl = null;
+    }
+
+    // Remove GeoAgent control
+    if (this.geoAgentControl && this.map) {
+      if (this.geoAgentStateHandler) {
+        this.geoAgentControl.off('collapse', this.geoAgentStateHandler);
+        this.geoAgentControl.off('expand', this.geoAgentStateHandler);
+        this.geoAgentControl.off('statechange', this.geoAgentStateHandler);
+        this.geoAgentStateHandler = null;
+      }
+      this.geoAgentEventGuardCleanup?.();
+      this.geoAgentEventGuardCleanup = null;
+      this.map.removeControl(this.geoAgentControl as unknown as maplibregl.IControl);
+      this.controlsMap.delete('geoagent-control');
+      this.geoAgentControl = null;
     }
 
     // Remove control grid

--- a/src/maplibre/index.ts
+++ b/src/maplibre/index.ts
@@ -18,6 +18,8 @@ import 'maplibre-gl-layer-control/style.css';
 import 'maplibre-gl-lidar/style.css';
 // Import GeoPhoto Control CSS
 import 'maplibre-gl-geophoto/style.css';
+// Import GeoAgent Control CSS
+import 'maplibre-gl-geoagent/style.css';
 // Import custom anymap-ts styles (dark mode overrides, tooltip, controls)
 import '../styles/maplibre.css';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
         'maplibre-contour': resolve(__dirname, 'examples/maplibre/contour_layer.html'),
         'maplibre-control-grid': resolve(__dirname, 'examples/maplibre/control_grid.html'),
         'maplibre-geophoto': resolve(__dirname, 'examples/maplibre/geophoto_layer.html'),
+        'maplibre-geoagent': resolve(__dirname, 'examples/maplibre/geoagent_control.html'),
         'maplibre-pmtiles': resolve(__dirname, 'examples/maplibre/pmtiles_layer.html'),
         // Other map libraries
         leaflet: resolve(__dirname, 'examples/leaflet/index.html'),


### PR DESCRIPTION
- Implemented GeoAgent control in MapLibreMap class with methods to add, remove, and set state.
- Updated HTML template to include GeoAgent CSS and JavaScript.
- Created example for GeoAgent control in examples/maplibre/geoagent_control.html.
- Added GeoAgent control to the main map example in geoagent-main.ts.
- Updated documentation to include GeoAgent control usage in geoagent.ipynb.
- Modified mkdocs.yml to include GeoAgent documentation.
- Updated package.json to include maplibre-gl-geoagent dependency.
- Enhanced MapLibreRenderer to handle GeoAgent control lifecycle and events.