### PR TITLE
Stop draw control from hijacking Ctrl+C/V outside the map

### DIFF
--- a/src/maplibre/plugins/GeoEditorPlugin.ts
+++ b/src/maplibre/plugins/GeoEditorPlugin.ts
@@ -134,6 +134,10 @@ export class GeoEditorPlugin {
       originalHandler(event);
     };
     document.addEventListener('keydown', wrappedHandler);
+    // Point the editor's own reference at our wrapper so its `onRemove`
+    // (called via `map.removeControl(geoEditor)`) cleans up the right
+    // listener even when callers bypass `GeoEditorPlugin.destroy()`.
+    editor.boundKeyHandler = wrappedHandler;
     this.wrappedKeyHandler = wrappedHandler;
   }
 

--- a/src/maplibre/plugins/GeoEditorPlugin.ts
+++ b/src/maplibre/plugins/GeoEditorPlugin.ts
@@ -26,6 +26,7 @@ export class GeoEditorPlugin {
   private geoman: Geoman | null = null;
   private geoEditor: GeoEditor | null = null;
   private onDataChange: ((data: FeatureCollection) => void) | null = null;
+  private wrappedKeyHandler: ((e: KeyboardEvent) => void) | null = null;
 
   constructor(map: MapLibreMap) {
     this.map = map;
@@ -80,6 +81,11 @@ export class GeoEditorPlugin {
 
         // Add control to map
         this.map.addControl(this.geoEditor, position);
+
+        // Scope the editor's document-level keyboard shortcuts to the map
+        // container so they don't hijack Ctrl+C/V/Z/Y outside the widget
+        // (e.g. in Marimo/Jupyter cell editors). See issue #175.
+        this.scopeKeyboardShortcutsToMap();
       } catch (error) {
         console.error('Failed to create GeoEditor:', error);
       }
@@ -98,6 +104,37 @@ export class GeoEditorPlugin {
         createGeoEditor();
       }
     }, 1000);
+  }
+
+  /**
+   * Replace the geo-editor's document-level keydown handler with a wrapper
+   * that only delegates to the original when the event originated inside the
+   * map container. The upstream handler unconditionally calls
+   * `preventDefault()` on Ctrl+C/V/Z/Y, which hijacks copy/paste/undo/redo in
+   * Marimo or Jupyter cells when the widget is rendered. See issue #175.
+   */
+  private scopeKeyboardShortcutsToMap(): void {
+    if (!this.geoEditor) return;
+
+    // boundKeyHandler is a private field on GeoEditor; access defensively.
+    const editor = this.geoEditor as unknown as {
+      boundKeyHandler?: ((e: KeyboardEvent) => void) | null;
+    };
+    const originalHandler = editor.boundKeyHandler;
+    if (typeof originalHandler !== 'function') return;
+
+    document.removeEventListener('keydown', originalHandler);
+
+    const mapContainer = this.map.getContainer();
+    const wrappedHandler = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || !mapContainer.contains(target)) {
+        return;
+      }
+      originalHandler(event);
+    };
+    document.addEventListener('keydown', wrappedHandler);
+    this.wrappedKeyHandler = wrappedHandler;
   }
 
   /**
@@ -198,6 +235,10 @@ export class GeoEditorPlugin {
    * Destroy the geo editor.
    */
   destroy(): void {
+    if (this.wrappedKeyHandler) {
+      document.removeEventListener('keydown', this.wrappedKeyHandler);
+      this.wrappedKeyHandler = null;
+    }
     if (this.geoEditor) {
       this.map.removeControl(this.geoEditor);
       this.geoEditor = null;

--- a/tests/typescript/GeoEditorPlugin.test.ts
+++ b/tests/typescript/GeoEditorPlugin.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { GeoEditor } from 'maplibre-gl-geo-editor';
+import { Geoman } from '@geoman-io/maplibre-geoman-free';
+import { GeoEditorPlugin } from '../../src/maplibre/plugins/GeoEditorPlugin';
+
+interface MockEditorState {
+  boundKeyHandler: ((e: KeyboardEvent) => void) | null;
+}
+
+function setupMocks(): {
+  mapContainer: HTMLElement;
+  outsideElement: HTMLElement;
+  map: any;
+  editorState: MockEditorState;
+  capturedKeyEvents: KeyboardEvent[];
+} {
+  const mapContainer = document.createElement('div');
+  mapContainer.id = 'map-root';
+  document.body.appendChild(mapContainer);
+
+  const outsideElement = document.createElement('textarea');
+  outsideElement.id = 'notebook-cell';
+  document.body.appendChild(outsideElement);
+
+  const editorState: MockEditorState = { boundKeyHandler: null };
+  const capturedKeyEvents: KeyboardEvent[] = [];
+
+  // Simulate the upstream geo-editor: register a document-level keydown
+  // listener as part of `addControl` (which fires the editor's onAdd).
+  const map: any = {
+    addControl: vi.fn().mockImplementation(() => {
+      const handler = (event: KeyboardEvent) => {
+        capturedKeyEvents.push(event);
+      };
+      editorState.boundKeyHandler = handler;
+      document.addEventListener('keydown', handler);
+    }),
+    removeControl: vi.fn().mockImplementation(() => {
+      if (editorState.boundKeyHandler) {
+        document.removeEventListener('keydown', editorState.boundKeyHandler);
+        editorState.boundKeyHandler = null;
+      }
+    }),
+    on: vi.fn(),
+    getContainer: vi.fn().mockReturnValue(mapContainer),
+  };
+
+  vi.mocked(GeoEditor).mockImplementationOnce(function MockGeoEditor() {
+    const instance: any = {
+      setGeoman: vi.fn(),
+      getFeatures: vi.fn().mockReturnValue({ type: 'FeatureCollection', features: [] }),
+      loadGeoJson: vi.fn(),
+      selectFeatures: vi.fn(),
+      deleteSelectedFeatures: vi.fn(),
+      getSelectedFeatures: vi.fn().mockReturnValue([]),
+      enableDrawMode: vi.fn(),
+      enableEditMode: vi.fn(),
+      disableAllModes: vi.fn(),
+    };
+    // The plugin reads `boundKeyHandler` directly off the editor after
+    // addControl runs, so expose it as a live getter on the mock.
+    Object.defineProperty(instance, 'boundKeyHandler', {
+      configurable: true,
+      get: () => editorState.boundKeyHandler,
+      set: (value: ((e: KeyboardEvent) => void) | null) => {
+        editorState.boundKeyHandler = value;
+      },
+    });
+    return instance;
+  });
+
+  vi.mocked(Geoman).mockImplementationOnce(function MockGeoman() {
+    return {} as any;
+  });
+
+  return { mapContainer, outsideElement, map, editorState, capturedKeyEvents };
+}
+
+describe('GeoEditorPlugin keyboard scoping (issue #175)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('does not forward keydown events fired outside the map container', () => {
+    const { mapContainer, outsideElement, map, editorState, capturedKeyEvents } = setupMocks();
+
+    const plugin = new GeoEditorPlugin(map);
+    plugin.initialize({}, vi.fn());
+
+    // Force the gm:loaded fallback timeout to create the GeoEditor.
+    vi.advanceTimersByTime(1100);
+
+    expect(map.addControl).toHaveBeenCalledTimes(1);
+    // The plugin must have replaced the upstream listener: the upstream
+    // boundKeyHandler is no longer registered on `document`.
+    expect(editorState.boundKeyHandler).not.toBeNull();
+
+    // Fire a Ctrl+C from a "notebook cell" outside the map — the upstream
+    // handler must NOT see it.
+    outsideElement.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'c',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(capturedKeyEvents).toHaveLength(0);
+
+    // Fire the same shortcut from inside the map container — the upstream
+    // handler must still receive it so map shortcuts keep working.
+    mapContainer.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'c',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(capturedKeyEvents).toHaveLength(1);
+    expect(capturedKeyEvents[0].key).toBe('c');
+  });
+
+  it('removes the wrapped keydown listener on destroy', () => {
+    const { mapContainer, map, capturedKeyEvents } = setupMocks();
+
+    const plugin = new GeoEditorPlugin(map);
+    plugin.initialize({}, vi.fn());
+    vi.advanceTimersByTime(1100);
+
+    plugin.destroy();
+
+    mapContainer.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'c',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(capturedKeyEvents).toHaveLength(0);
+  });
+});

--- a/tests/typescript/GeoEditorPlugin.test.ts
+++ b/tests/typescript/GeoEditorPlugin.test.ts
@@ -77,12 +77,19 @@ function setupMocks(): {
 }
 
 describe('GeoEditorPlugin keyboard scoping (issue #175)', () => {
+  let activePlugin: GeoEditorPlugin | null = null;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    // Always destroy the plugin so the document-level keydown listener it
+    // installs doesn't leak across tests (jsdom keeps `document` between
+    // tests; clearing `document.body.innerHTML` does not remove listeners).
+    activePlugin?.destroy();
+    activePlugin = null;
     vi.useRealTimers();
     document.body.innerHTML = '';
   });
@@ -91,6 +98,7 @@ describe('GeoEditorPlugin keyboard scoping (issue #175)', () => {
     const { mapContainer, outsideElement, map, editorState, capturedKeyEvents } = setupMocks();
 
     const plugin = new GeoEditorPlugin(map);
+    activePlugin = plugin;
     plugin.initialize({}, vi.fn());
 
     // Force the gm:loaded fallback timeout to create the GeoEditor.
@@ -133,10 +141,12 @@ describe('GeoEditorPlugin keyboard scoping (issue #175)', () => {
     const { mapContainer, map, capturedKeyEvents } = setupMocks();
 
     const plugin = new GeoEditorPlugin(map);
+    activePlugin = plugin;
     plugin.initialize({}, vi.fn());
     vi.advanceTimersByTime(1100);
 
     plugin.destroy();
+    activePlugin = null;
 
     mapContainer.dispatchEvent(
       new KeyboardEvent('keydown', {


### PR DESCRIPTION
Closes #175.

## Summary
- The draw control internally uses `maplibre-gl-geo-editor`, whose `onAdd` installs a `document.addEventListener("keydown", ...)` listener that unconditionally calls `preventDefault()` on Ctrl+C, Ctrl+V, Ctrl+Z, and Ctrl+Y. This swallows copy/paste in unrelated cell editors when the widget is rendered in a Marimo or Jupyter notebook.
- `GeoEditorPlugin` now wraps that upstream handler so it only fires when `event.target` is a descendant of the map container, and removes the wrapper on `destroy()`.

## Test plan
- [x] `npx vitest run` (40 passed, including 2 new tests in `tests/typescript/GeoEditorPlugin.test.ts`)
- [x] `npm run typecheck`
- [x] `npx eslint src/maplibre/plugins/GeoEditorPlugin.ts` (no new warnings)
- [x] `pre-commit run --all-files`
- [ ] Manually verify in a Marimo notebook that Ctrl+C/Ctrl+V work in cells after rendering a `Map` with `add_draw_control()`, and that Ctrl+C/V still copy/paste features inside the map.